### PR TITLE
chore: add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+# Variables
+NODE_VERSION_MIN = 18.12
+
+
+.PHONY: dev-build 
+
+default: dev-build
+
+# Ensure Node.js version meets the minimum requirement
+check-node-version:
+	@echo "Checking Node.js version..."
+	@node_version=$$(node -v | sed 's/v//'); \
+	if [ "$$node_version" \< "$(NODE_VERSION_MIN)" ]; then \
+		echo "Error: Node.js version must be at least $(NODE_VERSION_MIN)"; \
+		exit 1; \
+	fi
+	@echo "Node.js version is adequate."
+
+# Install dependencies
+install-dependencies: check-node-version
+	@echo "Installing dependencies..."
+	npm install -g pnpm && pnpm install
+
+# Start desktop development
+start-dev: install-dependencies
+	@echo "Starting desktop development..."
+	pnpm tauri dev
+
+# Build desktop application for MacOS
+build-mac-app: install-dependencies
+	@echo "Building the desktop application..."
+	pnpm tauri build --bundles app
+
+# Build DMG package for MacOS
+build-mac-dmg: install-dependencies
+	@echo "Building the desktop dmg package..."
+	pnpm tauri build --bundles dmg
+
+# Combined: Install dependencies, start dev, and build app
+dev-build: install-dependencies start-dev build-app
+	@echo "Development and build process completed."
+
+# Clean up node_modules and rebuild
+clean-rebuild:
+	@echo "Cleaning up and rebuilding..."
+	rm -rf node_modules
+	$(MAKE) dev-build


### PR DESCRIPTION
This pull request introduces several new targets and checks to the `Makefile` to streamline the development and build process for a desktop application. The most important changes include setting a minimum Node.js version requirement, adding targets for installing dependencies, starting development, and building the application, and creating a clean rebuild process.

Makefile enhancements:

* Added a variable `NODE_VERSION_MIN` to specify the minimum required Node.js version.
* Introduced a `check-node-version` target to ensure the Node.js version meets the minimum requirement before proceeding.
* Added `install-dependencies` target to install necessary dependencies using `pnpm`.
* Created `start-dev`, `build-mac-app`, and `build-mac-dmg` targets to handle starting development and building the application for MacOS.
* Implemented a `clean-rebuild` target to remove `node_modules` and rebuild the project from scratch.