### PR TITLE
chore: optimize makefile, don't call install-dependencies for each build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ start-dev: install-dependencies
 	pnpm tauri dev
 
 # Build desktop application for MacOS
-build-mac-app: install-dependencies
+build-mac-app: 
 	@echo "Building the desktop application..."
 	pnpm tauri build --bundles app
 
 # Build DMG package for MacOS
-build-mac-dmg: install-dependencies
+build-mac-dmg: 
 	@echo "Building the desktop dmg package..."
 	pnpm tauri build --bundles dmg
 


### PR DESCRIPTION
This pull request includes changes to the `Makefile` to remove the `install-dependencies` step from the `build-mac-app` and `build-mac-dmg` targets. 

Changes to `Makefile`:

* Removed the `install-dependencies` step from the `build-mac-app` target.
* Removed the `install-dependencies` step from the `build-mac-dmg` target.