### PR TITLE
feat: no task bar or resizable by default

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,6 +20,8 @@
         "decorations": false,
         "minimizable": false,
         "maximizable": false,
+        "skipTaskbar": true,
+        "resizable": false,
         "shadow": false,
         "transparent": true,
         "fullscreen": false,


### PR DESCRIPTION
This pull request includes a small change to the `src-tauri/tauri.conf.json` file. The change adds two new properties to the configuration: `skipTaskbar` and `resizable`.

Configuration updates:

* [`src-tauri/tauri.conf.json`](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7R23-R24): Added `skipTaskbar` and `resizable` properties to the window configuration.