### PR TITLE
fix: resolve search hang issue after multiple queries

### DIFF
--- a/src/components/AppAI/InputBox.tsx
+++ b/src/components/AppAI/InputBox.tsx
@@ -81,7 +81,7 @@ export default function ChatInput({
       }
 
       if (pressedKeys.has("MetaLeft") || pressedKeys.has("MetaRight")) {
-        e.preventDefault();
+        // e.preventDefault();
         switch (e.code) {
           case "Comma":
             setIsCommandPressed(false);


### PR DESCRIPTION
This pull request includes a small change to the `src/components/AppAI/InputBox.tsx` file. The change comments out a line that prevents the default action when the Meta key is pressed.

* [`src/components/AppAI/InputBox.tsx`](diffhunk://#diff-d6d676e884b2d9c7e9ae52426e13fb27efad5dd5ca7f2161ce38e71dd7d11868L84-R84): Commented out `e.preventDefault()` within the `if (pressedKeys.has("MetaLeft") || pressedKeys.has("MetaRight"))` block.