### PR TITLE
feat: allow to launch coco across multi monitors

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,5 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-
 fn main() {
     coco_lib::run();
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -71,14 +71,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": [
-      "nsis",
-      "dmg",
-      "app",
-      "appimage",
-      "deb",
-      "rpm"
-    ],
+    "targets": "all",
     "shortDescription": "Coco AI",
     "icon": [
       "icons/32x32.png",
@@ -103,11 +96,11 @@
       "dmg": {
         "appPosition": {
           "x": 180,
-          "y": 140
+          "y": 180
         },
         "applicationFolderPosition": {
           "x": 480,
-          "y": 140
+          "y": 180
         }
       }
     },

--- a/src/main.css
+++ b/src/main.css
@@ -14,6 +14,7 @@
     --background: #ffffff;
     --foreground: #09090b;
     --border: #e3e3e7;
+    --coco-primary-color: rgb(149, 5, 153);
 }
 
 /* Light theme */


### PR DESCRIPTION
This pull request includes several changes to the `src-tauri/src/lib.rs` file to improve the application's initialization and window management processes. The most important changes include adding a new function to move the application window to the active monitor, running initialization tasks in the background, and making minor adjustments to function calls and imports.

### Improvements to window management:

* Added the `move_window_to_active_monitor` function to move the application window to the active monitor when the "Open Coco" menu is clicked. This function handles monitor detection and cursor position gracefully. (`src-tauri/src/lib.rs`)
* Updated the `handle_open_coco` function to call `move_window_to_active_monitor` before showing the window and setting its properties. (`src-tauri/src/lib.rs`)

### Background initialization tasks:

* Cloned `app_handle` to move it into a background task for initializing the application search source. (`src-tauri/src/lib.rs`)
* Registered the application search source in the background task to improve performance. (`src-tauri/src/lib.rs`)

### Minor adjustments:

* Modified the `run` function to pass a reference to `enable_shortcut`. (`src-tauri/src/lib.rs`)
* Updated imports to include `PhysicalPosition` and `Window`. (`src-tauri/src/lib.rs`)