### PR TITLE
fix: allow the to access deeplink for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install-dependencies: check-node-version
 # Start desktop development
 start-dev: install-dependencies
 	@echo "Starting desktop development..."
-	pnpm tauri dev
+	RUST_BACKTRACE=1 pnpm tauri dev
 
 # Build desktop application for MacOS
 build-mac-app: 
@@ -68,7 +68,7 @@ build-linux-appimage: install-dependencies
 	pnpm tauri build --bundles appimage
 
 # Combined: Install dependencies, start dev, and build app
-dev-build: install-dependencies start-dev build-app
+dev-build: install-dependencies start-dev
 	@echo "Development and build process completed."
 
 # Clean up node_modules and rebuild

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,6 +12,9 @@ Information about release notes of Coco Server is provided here.
 ### Features
 ### Breaking changes
 ### Bug fix
+- Fix to access deeplink for linux #148
+
+
 ### Improvements
 
 ## 0.1.0 (2015-02-16)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4982,6 +4982,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
+ "tauri-plugin-deep-link",
  "thiserror 2.0.6",
  "tracing",
  "windows-sys 0.59.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,7 +14,11 @@ name = "coco_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build = { version = "2", features = ["default"] }
+
+[features]
+default = ["desktop"]
+desktop = []
 
 [dependencies]
 pizza-common = { git = "https://github.com/infinilabs/pizza-common", branch = "main" }
@@ -27,7 +31,6 @@ tauri-plugin-http = "2"
 tauri-plugin-websocket = "2"
 tauri-plugin-theme = "2.1.2"
 tauri-plugin-deep-link = "2.0.0"
-tauri-plugin-single-instance = "2.0.0"
 tauri-plugin-store = "2.2.0"
 tauri-plugin-os = "2"
 tauri-plugin-dialog = "2"
@@ -55,6 +58,10 @@ fuzzy_prefix_search = "0.2"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2" }
+
+[target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]
+tauri-plugin-single-instance = { version = "2.0.0", features = ["deep-link"] }
+
 
 [profile.dev]
 incremental = true # Compile your binary in smaller steps.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -49,6 +49,7 @@
     "global-shortcut:allow-unregister",
     "global-shortcut:allow-unregister-all",
     "theme:default",
+    "core:event:default",
     "deep-link:allow-get-current",
     "deep-link:default",
     "deep-link:allow-register",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
-  "productName": "Coco AI",
+  "productName": "Coco-AI",
   "version": "../package.json",
   "identifier": "rs.coco.app",
   "build": {
@@ -21,7 +21,7 @@
         "decorations": false,
         "minimizable": false,
         "maximizable": false,
-        "skipTaskbar": false,
+        "skipTaskbar": true,
         "resizable": false,
         "alwaysOnTop": true,
         "acceptFirstMouse": true,
@@ -37,6 +37,7 @@
       },
       {
         "label": "settings",
+        "title": "Coco AI Settings",
         "url": "/ui/settings",
         "width": 1000,
         "height": 700,


### PR DESCRIPTION
## What does this PR do

Handle proper permission setting, remove whitespace from output's product name.

Passed for AppImage package, after execute the Appimage, it will create a `.desktop` file to associate protocol with coco:
```
ubuntu@ubuntu:~/.local/share/applications$ cat coco-handler.desktop 
[Desktop Entry]
Type=Application
Name=Coco-AI
Exec=/home/ubuntu/Documents/Coco-AI_0.1.0_aarch64.AppImage %u
Terminal=false
NoDisplay=true
MimeType=x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco;x-scheme-handler/coco
```

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation