### PR TITLE
chore: the development environment automatically opens the console in the main window

### DIFF
--- a/src-tauri/src/setup/mod.rs
+++ b/src-tauri/src/setup/mod.rs
@@ -19,5 +19,9 @@ pub use windows::*;
 pub use linux::*;
 
 pub fn default(app: &mut App, main_window: WebviewWindow, settings_window: WebviewWindow) {
+    // Development mode automatically opens the console: https://tauri.app/develop/debug
+    #[cfg(any(dev, debug_assertions))]
+    main_window.open_devtools();
+
     platform(app, main_window.clone(), settings_window.clone());
 }


### PR DESCRIPTION
## What does this PR do
the development environment automatically opens the console in the main window
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation