### PR TITLE
fix: fix macos double-click on main window crashes

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,11 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": [
-    "main",
-    "chat",
-    "settings"
-  ],
+  "windows": ["main", "chat", "settings"],
   "permissions": [
     "core:default",
     "core:event:allow-emit",
@@ -32,6 +28,7 @@
     "core:window:allow-get-all-windows",
     "core:window:allow-set-focus",
     "core:window:allow-set-always-on-top",
+    "core:window:deny-internal-toggle-maximize",
     "core:app:allow-set-app-theme",
     "shell:default",
     "http:default",


### PR DESCRIPTION
## What does this PR do
fix macos double-click on main window crashes
## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation