### PR TITLE
refactor: disable right-click for production environment

### DIFF
--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from "react";
 import { Outlet, useLocation } from "react-router-dom";
-import { useTranslation } from 'react-i18next';
-import { listen } from '@tauri-apps/api/event';
+import { useTranslation } from "react-i18next";
+import { listen } from "@tauri-apps/api/event";
 
-import { useAppStore } from '@/stores/appStore';
+import { useAppStore } from "@/stores/appStore";
 import useEscape from "@/hooks/useEscape";
 import useSettingsWindow from "@/hooks/useSettingsWindow";
+import { useEventListener } from "ahooks";
 
 export default function Layout() {
   const location = useLocation();
@@ -35,15 +36,22 @@ export default function Layout() {
       i18n.changeLanguage(language);
     }
 
-    const unlistenLanguageChange = listen('language-changed', (event: any) => {
+    const unlistenLanguageChange = listen("language-changed", (event: any) => {
       const { language } = event.payload;
       i18n.changeLanguage(language);
     });
 
     return () => {
-      unlistenLanguageChange.then(unlisten => unlisten());
+      unlistenLanguageChange.then((unlisten) => unlisten());
     };
   }, []);
+
+  // Disable right-click for production environment
+  useEventListener("contextmenu", (event) => {
+    if (import.meta.env.DEV) return;
+
+    event.preventDefault();
+  });
 
   return <Outlet />;
 }


### PR DESCRIPTION
## What does this PR do
disable right-click for production environment
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation