### PR TITLE
chore: refresh all server's info on purpose, get the actual health info

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -30,6 +30,8 @@ Information about release notes of Coco Server is provided here.
 - Refactoring assistant api #195
 - Refactor: remove websocket_session_id from message request #206
 - Refactor: the display of search results and the logic of creating new chats #207
+- Refresh all server's info on purpose, get the actual health info #225
+
 
 ## 0.1.0 (2015-02-16)
 


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation