### PR TITLE
fix: server should keep previous enabled state even on fresh

### DIFF
--- a/src-tauri/src/server/servers.rs
+++ b/src-tauri/src/server/servers.rs
@@ -303,6 +303,7 @@ pub async fn refresh_coco_server_info<R: Runtime>(
     };
 
     if let Some(server) = server {
+        let is_enabled = server.enabled;
         let is_builtin = server.builtin;
         let profile = server.profile;
 
@@ -319,6 +320,7 @@ pub async fn refresh_coco_server_info<R: Runtime>(
                         Ok(mut server) => {
                             server.id = id.clone();
                             server.builtin = is_builtin;
+                            server.builtin = is_enabled;
                             server.available = true;
                             server.profile = profile;
                             trim_endpoint_last_forward_slash(&mut server);

--- a/src-tauri/src/server/servers.rs
+++ b/src-tauri/src/server/servers.rs
@@ -320,7 +320,7 @@ pub async fn refresh_coco_server_info<R: Runtime>(
                         Ok(mut server) => {
                             server.id = id.clone();
                             server.builtin = is_builtin;
-                            server.builtin = is_enabled;
+                            server.enabled = is_enabled;
                             server.available = true;
                             server.profile = profile;
                             trim_endpoint_last_forward_slash(&mut server);


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation