### PR TITLE
ci: remove unneeded rust-toolchain action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup toolchain install stable
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
## What does this PR do

Remove an unnecessary action `dtolnay/rust-toolchain`.

Github Action already has `rustup` installed in the CI environments, which means you don't need a separate action to install Rust toolchains

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes

  No need to write release note for this change
  
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation