### PR TITLE
chore: lock `tauri-plugin-fs-pro` version to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
-    "tauri-plugin-fs-pro-api": "^2.3.1",
+    "tauri-plugin-fs-pro-api": "2.3.1",
     "tauri-plugin-macos-permissions-api": "^2.2.0",
     "tauri-plugin-screenshots-api": "^2.1.0",
     "tauri-plugin-windows-version-api": "^2.0.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,7 +41,7 @@ tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-drag = "2"
 tauri-plugin-macos-permissions = "2"
-tauri-plugin-fs-pro = "2"
+tauri-plugin-fs-pro = "=2.3.1"
 tauri-plugin-screenshots = "2"
 applications = { git = "https://github.com/infinilabs/applications-rs", rev = "2345d3b86b711b03aa9aee6920e0108d81a8edb9" }
 


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation