### PR TITLE
fix: correct app default search path on macOS

### DIFF
--- a/src-tauri/src/local/application.rs
+++ b/src-tauri/src/local/application.rs
@@ -150,7 +150,7 @@ impl ApplicationSearchSource {
         let application_paths = Trie::new();
         let mut icons = HashMap::new();
 
-        let default_search_path = applications::get_default_search_paths();
+        let default_search_path = get_default_search_paths().into_iter().map(PathBuf::from).collect();
         let mut ctx = AppInfoContext::new(default_search_path);
         ctx.refresh_apps().map_err(|err| err.to_string())?; // must refresh apps before getting them
         let apps = ctx.get_all_apps();


### PR DESCRIPTION
## What does this PR do

Fix the issue that app search does not work on macOS

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation