### PR TITLE
fix: filter http query_args and convert only supported values

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -31,6 +31,7 @@ Information about release notes of Coco Server is provided here.
 - fix: active shadow setting #354
 - fix: chat history was not show up #377
 - fix: get attachments in chat sessioins
+- fix: filter http query_args and convert only supported values
 
 ### Improvements
 

--- a/src-tauri/src/server/http_client.rs
+++ b/src-tauri/src/server/http_client.rs
@@ -82,8 +82,23 @@ impl HttpClient {
         }
 
         if let Some(query) = query_params {
-            let query: HashMap<String, String> =
-                query.into_iter().map(|(k, v)| (k, v.to_string())).collect();
+            // Convert only supported value types into strings
+            let query: HashMap<String, String> = query
+                .into_iter()
+                .filter_map(|(k, v)| {
+                    match v {
+                        JsonValue::String(s) => Some((k, s)),
+                        JsonValue::Number(n) => Some((k, n.to_string())),
+                        JsonValue::Bool(b) => Some((k, b.to_string())),
+                        _ => {
+                            dbg!(
+                                "Unsupported query parameter type. Only strings, numbers, and booleans are supported.",k,v,
+                            );
+                            None
+                        } // skip arrays, objects, nulls
+                    }
+                })
+                .collect();
             request_builder = request_builder.query(&query);
         }
 
@@ -169,7 +184,7 @@ impl HttpClient {
             query_params,
             body,
         )
-        .await
+            .await
     }
 
     // Convenience method for PUT requests
@@ -189,7 +204,7 @@ impl HttpClient {
             query_params,
             body,
         )
-        .await
+            .await
     }
 
     // Convenience method for DELETE requests
@@ -208,6 +223,6 @@ impl HttpClient {
             query_params,
             None,
         )
-        .await
+            .await
     }
 }


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation