### PR TITLE
fix: correct datasource ID in returned documents

### DIFF
--- a/src-tauri/src/local/application.rs
+++ b/src-tauri/src/local/application.rs
@@ -11,6 +11,8 @@ use std::path::PathBuf;
 use tauri::{AppHandle, Runtime};
 use tauri_plugin_fs_pro::{icon, metadata, name, IconOptions};
 
+const DATA_SOURCE_ID: &str = "Applications";
+
 #[tauri::command]
 pub fn get_default_search_paths() -> Vec<String> {
     #[cfg(target_os = "macos")]
@@ -232,7 +234,7 @@ impl SearchSource for ApplicationSearchSource {
                 .unwrap_or("My Computer".into())
                 .to_string_lossy()
                 .into(),
-            id: "local_applications".into(),
+            id: DATA_SOURCE_ID.into(),
         }
     }
 
@@ -282,8 +284,8 @@ impl SearchSource for ApplicationSearchSource {
                 let mut doc = Document::new(
                     Some(DataSourceReference {
                         r#type: Some(LOCAL_QUERY_SOURCE_TYPE.into()),
-                        name: Some("Applications".into()),
-                        id: Some(app_name.clone()),
+                        name: Some(DATA_SOURCE_ID.into()),
+                        id: Some(DATA_SOURCE_ID.into()),
                         icon: None,
                     }),
                     app_path_string.clone(),

--- a/src-tauri/src/search/mod.rs
+++ b/src-tauri/src/search/mod.rs
@@ -17,6 +17,8 @@ pub async fn query_coco_fusion<R: Runtime>(
     size: u64,
     query_strings: HashMap<String, String>,
 ) -> Result<MultiSourceQueryResponse, SearchError> {
+    println!("DBG: query_string [{:?}]", query_strings);
+
     let search_sources = app_handle.state::<SearchSourceRegistry>();
 
     let sources_future = search_sources.get_sources();
@@ -41,7 +43,7 @@ pub async fn query_coco_fusion<R: Runtime>(
             timeout(timeout_duration, async {
                 query_source_clone.search(query).await
             })
-                .await
+            .await
         }));
     }
 

--- a/src-tauri/src/search/mod.rs
+++ b/src-tauri/src/search/mod.rs
@@ -17,7 +17,7 @@ pub async fn query_coco_fusion<R: Runtime>(
     size: u64,
     query_strings: HashMap<String, String>,
 ) -> Result<MultiSourceQueryResponse, SearchError> {
-    println!("DBG: query_string [{:?}]", query_strings);
+    let data_source_to_search = query_strings.get("datasource");
 
     let search_sources = app_handle.state::<SearchSourceRegistry>();
 
@@ -33,6 +33,14 @@ pub async fn query_coco_fusion<R: Runtime>(
     // Push all queries into futures
     for query_source in sources_list {
         let query_source_type = query_source.get_type().clone();
+
+        if let Some(data_source_to_search) = data_source_to_search {
+            // We should not search this data source
+            if &query_source_type.id != data_source_to_search {
+                continue;
+            }
+        }
+
         sources.insert(query_source_type.id.clone(), query_source_type);
 
         let query = SearchQuery::new(from, size, query_strings.clone());


### PR DESCRIPTION
## What does this PR do

1. Correct the `document.source.id` field in the returned documents.
2. In `query_coco_fusion()`, if the query string  `datasource` is present, use it to filter out the data sources that we should not search.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation