### PR TITLE
revert: Document constructor changed in #399

### DIFF
--- a/src-tauri/src/common/document.rs
+++ b/src-tauri/src/common/document.rs
@@ -57,7 +57,37 @@ pub struct Document {
 }
 
 impl Document {
-    pub fn new(document: Document) -> Self {
-        document
+    pub fn new(
+        source: Option<DataSourceReference>,
+        id: String,
+        category: String,
+        name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            id,
+            created: None,
+            updated: None,
+            source,
+            r#type: None,
+            category: Some(category),
+            subcategory: None,
+            categories: None,
+            rich_categories: None,
+            title: Some(name),
+            summary: None,
+            lang: None,
+            content: None,
+            icon: None,
+            thumbnail: None,
+            cover: None,
+            tags: None,
+            url: Some(url),
+            size: None,
+            metadata: None,
+            payload: None,
+            owner: None,
+            last_updated_by: None,
+        }
     }
 }

--- a/src-tauri/src/local/application.rs
+++ b/src-tauri/src/local/application.rs
@@ -282,19 +282,18 @@ impl SearchSource for ApplicationSearchSource {
 
                 total_hits += 1;
 
-                let mut doc = Document::new(Document {
-                    id: app_path_string.clone(),
-                    title: Some(app_name.clone()),
-                    url: Some(app_path_string),
-                    category: Some("Application".to_string()),
-                    source: Some(DataSourceReference {
-                        r#type: Some(LOCAL_QUERY_SOURCE_TYPE.into()),
-                        name: Some(DATA_SOURCE_ID.into()),
-                        id: Some(DATA_SOURCE_ID.into()),
-                        icon: None,
-                    }),
-                    ..Default::default()
-                });
+                let mut doc = Document::new(
+                  Some(DataSourceReference {
+                      r#type: Some(LOCAL_QUERY_SOURCE_TYPE.into()),
+                      name: Some(DATA_SOURCE_ID.into()),
+                      id: Some(DATA_SOURCE_ID.into()),
+                      icon: None,
+                  }),
+                  app_path_string.clone(),
+                  "Application".to_string(),
+                  app_name.clone(),
+                  app_path_string.clone(),
+              );
 
                 // Attach icon if available
                 if let Some(icon_path) = self.icons.get(app_name.as_str()) {

--- a/src-tauri/src/local/calculator.rs
+++ b/src-tauri/src/local/calculator.rs
@@ -132,7 +132,7 @@ impl SearchSource for CalculatorSource {
                 payload.insert("query".to_string(), payload_query);
                 payload.insert("result".to_string(), payload_result);
 
-                let doc = Document::new(Document {
+                let doc = Document {
                     id: DATA_SOURCE_ID.to_string(),
                     category: Some(DATA_SOURCE_ID.to_string()),
                     payload: Some(payload),
@@ -143,7 +143,7 @@ impl SearchSource for CalculatorSource {
                         icon: None,
                     }),
                     ..Default::default()
-                });
+                };
 
                 return Ok(QueryResponse {
                     source: self.get_type(),


### PR DESCRIPTION
## What does this PR do

Revert the change to `Document::new()` in introduced in PR #399

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation