### PR TITLE
refactor: rename the key used to store queryTimeout

### DIFF
--- a/src/components/Settings/Advanced/index.tsx
+++ b/src/components/Settings/Advanced/index.tsx
@@ -34,10 +34,10 @@ const Advanced = () => {
     return state.setConnectionTimeout;
   });
   const queryTimeout = useConnectStore((state) => {
-    return state.queryTimeout;
+    return state.queryTimeoutRenamed;
   });
   const setQueryTimeout = useConnectStore((state) => {
-    return state.setQueryTimeout;
+    return state.setQueryTimeoutRenamed;
   });
 
   useEffect(() => {

--- a/src/hooks/useSyncStore.ts
+++ b/src/hooks/useSyncStore.ts
@@ -75,7 +75,7 @@ export const useSyncStore = () => {
     return state.setConnectionTimeout;
   });
   const setQueryTimeout = useConnectStore((state) => {
-    return state.setQueryTimeout;
+    return state.setQueryTimeoutRenamed;
   });
 
   useEffect(() => {
@@ -137,9 +137,9 @@ export const useSyncStore = () => {
       }),
 
       platformAdapter.listenEvent("change-connect-store", ({ payload }) => {
-        const { connectionTimeout, queryTimeout } = payload;
+        const { connectionTimeout, queryTimeoutRenamed } = payload;
         setConnectionTimeout(connectionTimeout);
-        setQueryTimeout(queryTimeout);
+        setQueryTimeout(queryTimeoutRenamed);
       }),
     ]);
 

--- a/src/stores/connectStore.ts
+++ b/src/stores/connectStore.ts
@@ -28,8 +28,8 @@ export type IConnectStore = {
   setAssistantList: (assistantList: []) => void;
   currentAssistant: any;
   setCurrentAssistant: (assistant: any) => void;
-  queryTimeout: number;
-  setQueryTimeout: (queryTimeout: number) => void;
+  queryTimeoutRenamed: number;
+  setQueryTimeoutRenamed: (queryTimeout: number) => void;
   visibleStartPage: boolean;
   setVisibleStartPage: (visibleStartPage: boolean) => void;
 };
@@ -107,9 +107,13 @@ export const useConnectStore = create<IConnectStore>()(
             })
           );
         },
-        queryTimeout: 5,
-        setQueryTimeout: (queryTimeout: number) => {
-          return set(() => ({ queryTimeout }));
+        queryTimeoutRenamed: 500,
+        setQueryTimeoutRenamed: (queryTimeout: number) => {
+          set(
+            produce((draft) => {
+              draft.queryTimeoutRenamed = queryTimeout;
+            })
+          );
         },
         visibleStartPage: false,
         setVisibleStartPage: (visibleStartPage: boolean) => {
@@ -124,7 +128,7 @@ export const useConnectStore = create<IConnectStore>()(
           datasourceData: state.datasourceData,
           connectionTimeout: state.connectionTimeout,
           currentAssistant: state.currentAssistant,
-          queryTimeout: state.queryTimeout,
+          queryTimeoutRenamed: state.queryTimeoutRenamed,
         }),
       }
     )


### PR DESCRIPTION
## What does this PR do

After this PR, we no longer use `queryTimeout` but `queryTimeoutRenamed` to store this configuration entry, requested by @medcl.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added

 I tested locally
 
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation