### PR TITLE
chore: add github action build arm64 platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,8 @@ jobs:
 
           - platform: "ubuntu-22.04"
             target: "x86_64-unknown-linux-gnu"
+          - platform: "ubuntu-22.04-arm"
+            target: "aarch64-unknown-linux-gnu"
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -67,10 +69,10 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: startsWith(matrix.platform, 'ubuntu-22.04')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
 
       - name: Install Rust stable
         run: rustup toolchain install stable


### PR DESCRIPTION
## What does this PR do
This pull request updates the release workflow to support an additional platform and improves dependency installation logic. The most important changes include adding support for the `ubuntu-22.04-arm` platform and refining the conditional logic and dependencies for Ubuntu-based builds.

### Platform support updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R53-R54): Added support for the `ubuntu-22.04-arm` platform with the `aarch64-unknown-linux-gnu` target.

### Dependency installation improvements:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L70-R75): Updated the conditional logic for installing dependencies to use `startsWith(matrix.platform, 'ubuntu-22.04')` for better flexibility.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L70-R75): Added `xdg-utils` to the list of dependencies installed for Ubuntu-based builds.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation