### PR TITLE
chore: use ssh instead of https to pull pizza_engine

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4619,7 +4619,7 @@ dependencies = [
 [[package]]
 name = "pizza-common"
 version = "0.1.0"
-source = "git+https://github.com/infinilabs/pizza#de36b19726d8bc4c4be21bdedcb5d24bdc6d7306"
+source = "git+ssh://git@github.com/infinilabs/pizza.git#de36b19726d8bc4c4be21bdedcb5d24bdc6d7306"
 dependencies = [
  "bytes",
  "camino",
@@ -4637,7 +4637,7 @@ dependencies = [
 [[package]]
 name = "pizza-engine"
 version = "0.1.0"
-source = "git+https://github.com/infinilabs/pizza#de36b19726d8bc4c4be21bdedcb5d24bdc6d7306"
+source = "git+ssh://git@github.com/infinilabs/pizza.git#de36b19726d8bc4c4be21bdedcb5d24bdc6d7306"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4664,7 +4664,7 @@ dependencies = [
  "num-traits",
  "ouroboros",
  "paste",
- "pizza-common 0.1.0 (git+https://github.com/infinilabs/pizza)",
+ "pizza-common 0.1.0 (git+ssh://git@github.com/infinilabs/pizza.git)",
  "rayon",
  "roaring",
  "rustc-hash",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,8 +27,7 @@ use_pizza_engine = ["dep:pizza-engine"]
 
 [dependencies]
 pizza-common = { git = "https://github.com/infinilabs/pizza-common", branch = "main" }
-pizza-engine = { git = "https://github.com/infinilabs/pizza", features = ["query_string_parser", "persistence"], optional = true }
-
+pizza-engine = { git = "ssh://git@github.com/infinilabs/pizza.git", features = ["query_string_parser", "persistence"], optional = true }
 
 tauri = { version = "2", features = ["protocol-asset", "macos-private-api", "tray-icon", "image-ico", "image-png", "unstable"] }
 tauri-plugin-shell = "2"


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation