### PR TITLE
fix: panic caused memory allocation failure on Linux

### DIFF
--- a/src-tauri/src/local/application/with_feature.rs
+++ b/src-tauri/src/local/application/with_feature.rs
@@ -357,9 +357,9 @@ impl Task for GetApplicationsTask {
     async fn exec(&mut self, state: &mut Option<Box<dyn SearchSourceState>>) {
         let callback = self.callback.take().unwrap();
 
-        // `size` is set to u32::MAX, it should be a reasonable value
+        // `size` is set to 100_000, it should be a reasonable value
         let dsl = r#"{
-        "size": 4294967295,
+        "size": 100000,
         "query": {
           "match_all": { }
         }


### PR DESCRIPTION
## What does this PR do

On Linux, the Coco app panicked with the following error:

```rust
memory allocation of xxx bytes failed
```

This line of code will https://github.com/infinilabs/pizza/blob/de36b19726d8bc4c4be21bdedcb5d24bdc6d7306/lib/engine/src/store/disk/mod.rs#L892 allocate `size * 2 * 8` bytes, and `size` was set too high, leading to an allocation failure. Decrease `size` to `100_000` to fix the issue.

Not quite sure why this didn't cause any issue on macOS, possibly because the allocator implementation difference between the 2 platforms.


## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation