### PR TITLE
fix: duplicate flatpak applications

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -117,7 +117,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 [[package]]
 name = "applications"
 version = "0.3.1"
-source = "git+https://github.com/infinilabs/applications-rs?rev=1f62cd25651733bf8dc961c2382a39335a26ffe7#1f62cd25651733bf8dc961c2382a39335a26ffe7"
+source = "git+https://github.com/infinilabs/applications-rs?rev=9a738215cb3bbd4fc7a563dbb44ec78271ee35f2#9a738215cb3bbd4fc7a563dbb44ec78271ee35f2"
 dependencies = [
  "anyhow",
  "cocoa 0.25.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,7 +62,7 @@ tauri-plugin-drag = "2"
 tauri-plugin-macos-permissions = "2"
 tauri-plugin-fs-pro = "2"
 tauri-plugin-screenshots = "2"
-applications = { git = "https://github.com/infinilabs/applications-rs", rev = "1f62cd25651733bf8dc961c2382a39335a26ffe7" }
+applications = { git = "https://github.com/infinilabs/applications-rs", rev = "9a738215cb3bbd4fc7a563dbb44ec78271ee35f2" }
 
 tokio-native-tls = "0.3"  # For wss connections
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## What does this PR do

Fix a bug where applications installed via Flatpak would be reported twice.

This PR does not contain any code changes, they are included in PR https://github.com/infinilabs/applications-rs/pull/6. See that PR description for the root cause of the bug and how it was resolved.


## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation