### PR TITLE
chore: add ~/Applications to search path on macOS

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -19,6 +19,7 @@ Information about release notes of Coco Server is provided here.
 - feat: support for snapshot version updates #480
 - feat: history list add put away button #482
 - feat: the chat input box supports multi-line input #490
+- feat: add `~/Applications` to the search path #493
 
 ### 🐛 Bug fix
 

--- a/src-tauri/src/local/application/with_feature.rs
+++ b/src-tauri/src/local/application/with_feature.rs
@@ -1,4 +1,5 @@
 use super::super::SearchSourceState;
+use super::super::Task;
 use super::super::RUNTIME_TX;
 use super::AppEntry;
 use super::AppMetadata;
@@ -31,7 +32,6 @@ use tauri_plugin_fs_pro::{icon, metadata, name, IconOptions};
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
 use tauri_plugin_store::StoreExt;
 use tokio::sync::oneshot::Sender as OneshotSender;
-use super::super::Task;
 
 const FIELD_APP_NAME: &str = "app_name";
 const FIELD_ICON_PATH: &str = "icon_path";
@@ -52,11 +52,20 @@ pub(crate) const QUERYSOURCE_ID_DATASOURCE_ID_DATASOURCE_NAME: &str = "Applicati
 
 pub fn get_default_search_paths() -> Vec<String> {
     #[cfg(target_os = "macos")]
-    return vec![
-        "/Applications".into(),
-        "/System/Applications".into(),
-        "/System/Library/CoreServices".into(),
-    ];
+    {
+        let home_dir =
+            PathBuf::from(std::env::var_os("HOME").expect("environment variable $HOME not found"));
+        return vec![
+            "/Applications".into(),
+            "/System/Applications".into(),
+            "/System/Library/CoreServices".into(),
+            home_dir
+                .join("Applications")
+                .into_os_string()
+                .into_string()
+                .expect("this path should be UTF-8 encoded"),
+        ];
+    }
 
     #[cfg(not(target_os = "macos"))]
     {


### PR DESCRIPTION
## What does this PR do

Add `~/Applications` to the search path, for web apps installed from Chrome, they live under this directory.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation