### PR TITLE
fix: server image loading failure

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -54,6 +54,7 @@ Information about release notes of Coco Server is provided here.
 - style: history component styles #528
 - fix: app icon & category icon #529
 - style: search error styles #533
+- fix: server image loading failure #534
 
 ## 0.4.0 (2025-04-27)
 

--- a/src/components/Assistant/ServerList.tsx
+++ b/src/components/Assistant/ServerList.tsx
@@ -205,6 +205,10 @@ export function ServerList({
                       src={server?.provider?.icon || logoImg}
                       alt={server.name}
                       className="w-6 h-6 rounded-full bg-gray-100 dark:bg-gray-800"
+                      onError={(e) => {
+                        const target = e.target as HTMLImageElement;
+                        target.src = logoImg;
+                      }}
                     />
                     <div className="text-left flex-1 min-w-0">
                       <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate max-w-[200px]">

--- a/src/components/Cloud/Cloud.tsx
+++ b/src/components/Cloud/Cloud.tsx
@@ -319,6 +319,10 @@ export default function Cloud() {
                 width="100%"
                 src={currentService?.provider?.banner || bannerImg}
                 alt="banner"
+                onError={(e) => {
+                  const target = e.target as HTMLImageElement;
+                  target.src = bannerImg;
+                }}
               />
             </div>
             <div className="flex items-center justify-between mb-4">

--- a/src/components/Cloud/Sidebar.tsx
+++ b/src/components/Cloud/Sidebar.tsx
@@ -38,6 +38,10 @@ export const Sidebar = forwardRef<{ refreshData: () => void }, SidebarProps>(
             src={item?.provider?.icon || cocoLogoImg}
             alt="LogoImg"
             className="w-5 h-5 flex-shrink-0"
+            onError={(e) => {
+              const target = e.target as HTMLImageElement;
+              target.src = cocoLogoImg;
+            }}
           />
           <span className="font-medium truncate max-w-[140px]">{item?.name}</span>
           <div className="flex-1" />


### PR DESCRIPTION
## What does this PR do

Before：

![image](https://github.com/user-attachments/assets/755eb279-699a-4b50-923c-a60859d1a5ac)

After：

![image](https://github.com/user-attachments/assets/38d3cef4-1d02-4397-b488-5d5751c97058)

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation