### PR TITLE
feat: dynamic log level via env var COCO_LOG

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -25,6 +25,7 @@ Information about release notes of Coco Server is provided here.
 - feat: websocket support self-signed TLS #504
 - feat: add option to allow self-signed certificates #509
 - feat: add AI summary component #518
+- feat: dynamic log level via env var COCO_LOG #535
 
 ### 🐛 Bug fix
 


### PR DESCRIPTION
## What does this PR do

Allow us to configure dynamic log levels via the environment variable `COCO_LOG`. (If it is not set, use the current default log level, **INFO**.)

Generally, it mirrors the behavior of [`env_logger`](https://docs.rs/env_logger/latest/env_logger/#enabling-logging). Syntax: `COCO_LOG=<target>=<level>[,...]`, it is a log level triple sequence, separated by commas. Every log level triple consists of 3 parts:

1. target - which is the Rust crate or module name
2. = - an equal sign
3. level - the log level, which is case insensitive, "TRACE" is equivalent to "tRaCe"

target and level are optional:

* When the log level is omitted, e.g., `COCO_LOG=coco_lib`, the *TRACE* level will be used. 
* When the target is omitted, the specified log level will apply to all the targets, i.e., all the Rust crates/modules

And the log level set for a specific target has higher priority than the log level set for all the targets.

### Some examples

  * I only want the logs that come from Coco-AI: `COCO_LOG=coco_lib`
  * I only want the Coco-AI logs with log level higher than or equal to DEBUG: `COCO_LOG=coco_lib=debug`
  * I want to disable Tauri's log; all the other logs should be accepted: `COCO_LOG=trace,tauri=off`
  * I do not want logs: `COCO_LOG=off` or `COCO_LOG=`


## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation