### PR TITLE
fix: panic when fetching app metadata on Windows

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -34,6 +34,7 @@ Information about release notes of Coco Server is provided here.
 - fix: loading chat history for potential empty attachments
 - fix: datasource & MCP list synchronization update #521
 - fix: show only enabled datasource & MCP list
+- fix: panic when fetching app metadata on Windows #538
 
 ### ✈️ Improvements
 

--- a/src-tauri/src/local/application/mod.rs
+++ b/src-tauri/src/local/application/mod.rs
@@ -12,7 +12,6 @@ pub use with_feature::*;
 #[cfg(not(feature = "use_pizza_engine"))]
 pub use without_feature::*;
 
-
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AppEntry {
@@ -24,14 +23,12 @@ pub struct AppEntry {
     is_disabled: bool,
 }
 
-
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppMetadata {
     name: String,
     r#where: String,
     size: u64,
-    icon: String,
     created: u128,
     modified: u128,
     last_opened: u128,

--- a/src/components/Settings/Extensions/index.tsx
+++ b/src/components/Settings/Extensions/index.tsx
@@ -45,7 +45,7 @@ export interface Plugin {
   onEnabledChange?: (enabled: boolean) => void;
 }
 
-interface ExtensionsContextType {
+export interface ExtensionsContextType {
   plugins: Plugin[];
   setPlugins: Dispatch<SetStateAction<Plugin[]>>;
   activeId?: string;


### PR DESCRIPTION
## What does this PR do

Fix a panic that would happen when fetching app metadata on Windows. It also corrects application names, "chrome" -> "Google Chrome".

![p](https://github.com/user-attachments/assets/b80d05e3-b7fe-4dbe-8902-2d51bf0bfce9)

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation