### PR TITLE
chore: add make cmd dev-build-with-pizza

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,3 +79,7 @@ clean-rebuild:
 
 add-dep-pizza-engine:
 	cd src-tauri && cargo add --git ssh://git@github.com/infinilabs/pizza.git pizza-engine --features query_string_parser,persistence
+
+dev-build-with-pizza: add-dep-pizza-engine
+	@echo "Starting desktop development with Pizza Engine pulled in..."
+	RUST_BACKTRACE=1 pnpm tauri dev --features use_pizza_engine


### PR DESCRIPTION
## What does this PR do

Add a Makefile command that starts a dev server with feature `use_pizza_engine` enabled

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation