### PR TITLE
ci: deny dep pizza-engine

### DIFF
--- a/.github/workflows/enforce-no-dep-pizza-engine.yml
+++ b/.github/workflows/enforce-no-dep-pizza-engine.yml
@@ -1,0 +1,17 @@
+name: Enforce no dependency pizza-engine
+
+on:
+  pull_request:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: 
+        run: |
+          # if cargo remove pizza-engine succeeds, then it is in our dependency list, fail the CI pipeline.
+          if cargo remove pizza-engine; then exit 1; fi


### PR DESCRIPTION
## What does this PR do

Adds a CI pipeline that checks if `pizza-engine` is in our dependency list, if yes, error out.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation