### PR TITLE
chore: mark unavailable server to offline on refresh info

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -78,6 +78,7 @@ Information about release notes of Coco Server is provided here.
 - chore: assistant keyboard events and mouse events #559
 - chore: web component start page config #560
 - chore: assistant chat placeholder & refactor input box components #566
+- chore: mark unavailable server to offline on refresh info #569
 
 ## 0.4.0 (2025-04-27)
 

--- a/src-tauri/src/server/servers.rs
+++ b/src-tauri/src/server/servers.rs
@@ -315,7 +315,16 @@ pub async fn refresh_coco_server_info<R: Runtime>(
     // Send request to fetch updated server info
     let response = HttpClient::get(&id, "/provider/_info", None)
         .await
-        .map_err(|e| format!("Failed to contact the server: {}", e))?;
+        .map_err(|e| {
+            format!("Failed to contact the server: {}", e)
+        });
+
+    if response.is_err() {
+        let _ = mark_server_as_offline(app_handle, &id).await;
+        return Err(response.err().unwrap());
+    }
+
+    let response = response?;
 
     if !response.status().is_success() {
         let _ = mark_server_as_offline(app_handle, &id).await;


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation