### PR TITLE
fix: make extension search source respect parameter datasource

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -48,6 +48,7 @@ Information about release notes of Coco Server is provided here.
 - fix: suggestion list position #553
 - fix: independent chat window has no data #554
 - fix: resolved navigation error on continue chat action #558
+- fix: make extension search source respect parameter datasource #576
 
 ### ✈️ Improvements
 


### PR DESCRIPTION
## What does this PR do

1. Make the ThirdPartyExtensions SearchSource implementation respect the `datasource` parameter if it is specified.
2. Refactor the error handling and logging code in `query_coco_fusion()` to make it clearer.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation