### PR TITLE
chore: add pizza feature for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,37 @@ jobs:
       - name: Install app dependencies and build web
         run: pnpm install --frozen-lockfile
 
-      - name: Build the app
+      - name: Pizza engine features setup
+        if: matrix.platform != 'i686-pc-windows-msvc'
+        run: |
+          make add-dep-pizza-engine
+
+      - name: Build the app with ${{ matrix.platform }}
         uses: tauri-apps/tauri-action@v0
+        if: matrix.platform != 'i686-pc-windows-msvc'
+        env:
+          CI: false
+          PLATFORM: ${{ matrix.platform }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ""
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: Coco ${{ needs.create-release.outputs.APP_VERSION }}
+          releaseBody: ""
+          releaseDraft: true
+          prerelease: false
+          args: --target ${{ matrix.target }} --features use_pizza_engine
+
+      - name: Build the app with ${{ matrix.platform }} (windows i686 only)
+        uses: tauri-apps/tauri-action@v0
+        if: matrix.platform == 'i686-pc-windows-msvc'
         env:
           CI: false
           PLATFORM: ${{ matrix.platform }}


### PR DESCRIPTION
## What does this PR do
This pull request updates the release workflow in `.github/workflows/release.yml` to include conditional steps for setting up and building the application with specific features based on the target platform. The most important changes are as follows:

### Enhancements to the build process:

* **Pizza engine setup for non-Windows i686 platforms**: Added a new step to set up pizza engine features (`make add-dep-pizza-engine`) before building the app. This step is conditionally executed for platforms other than `i686-pc-windows-msvc`.

* **Platform-specific build configurations**: Updated the build step to include platform-specific configurations and environment variables. For non-Windows i686 platforms, the build now includes the `--features use_pizza_engine` argument.

* **Separate build step for Windows i686**: Introduced a distinct build step specifically for the `i686-pc-windows-msvc` platform, ensuring compatibility with this target.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation