### PR TITLE
chore: add ssh private key for pizza engine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,18 @@ jobs:
       - name: Install app dependencies and build web
         run: pnpm install --frozen-lockfile
 
+      - name: Set up SSH agent for private repository clone
+        if: matrix.platform != 'i686-pc-windows-msvc'
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Add Git server to known hosts
+        if: matrix.platform != 'i686-pc-windows-msvc'
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
       - name: Pizza engine features setup
         if: matrix.platform != 'i686-pc-windows-msvc'
         run: |


### PR DESCRIPTION
## What does this PR do
This pull request updates the `.github/workflows/release.yml` file to enhance the release workflow by adding steps for securely cloning a private repository on non-Windows platforms.

Enhancements to the release workflow:

* Added a step to set up an SSH agent for securely cloning private repositories, using the `webfactory/ssh-agent@v0.9.0` action and the `SSH_PRIVATE_KEY` secret. This step is skipped for Windows platforms.
* Added a step to add GitHub's server to the SSH known hosts file, ensuring secure SSH connections. This step is also skipped for Windows platforms.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation