### PR TITLE
chore: fix ci publish error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,25 +92,25 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Set up SSH agent for private repository clone
-        if: matrix.platform != 'i686-pc-windows-msvc'
+        if: matrix.target != 'i686-pc-windows-msvc'
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Add Git server to known hosts
-        if: matrix.platform != 'i686-pc-windows-msvc'
+        if: matrix.platform != 'windows-latest'
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
       - name: Pizza engine features setup
-        if: matrix.platform != 'i686-pc-windows-msvc'
+        if: matrix.target != 'i686-pc-windows-msvc'
         run: |
           make add-dep-pizza-engine
 
       - name: Build the app with ${{ matrix.platform }}
         uses: tauri-apps/tauri-action@v0
-        if: matrix.platform != 'i686-pc-windows-msvc'
+        if: matrix.target != 'i686-pc-windows-msvc'
         env:
           CI: false
           PLATFORM: ${{ matrix.platform }}
@@ -133,7 +133,7 @@ jobs:
 
       - name: Build the app with ${{ matrix.platform }} (windows i686 only)
         uses: tauri-apps/tauri-action@v0
-        if: matrix.platform == 'i686-pc-windows-msvc'
+        if: matrix.target == 'i686-pc-windows-msvc'
         env:
           CI: false
           PLATFORM: ${{ matrix.platform }}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -7,7 +7,13 @@ title: "Release Notes"
 
 Information about release notes of Coco Server is provided here.
 
-## 0.5.0 (In development)
+## Latest (In development)  
+### ❌ Breaking changes  
+### 🚀 Features  
+### 🐛 Bug fix  
+### ✈️ Improvements  
+
+## 0.5.1 (2025-05-31)
 
 ### ❌ Breaking changes
 


### PR DESCRIPTION
## What does this PR do
This pull request updates the `.github/workflows/release.yml` file to fix conditional checks for workflow steps, ensuring proper handling of the `matrix.target` and `matrix.platform` variables. The most important changes involve replacing outdated conditions to align with the intended logic.

### Workflow condition updates:

* Replaced `matrix.platform` with `matrix.target` in conditional checks for steps like setting up the SSH agent, adding the Git server to known hosts, and configuring the pizza engine features setup. This ensures the conditions correctly reference the intended matrix variable.
* Updated the condition for the Windows i686-specific build step to use `matrix.target` instead of `matrix.platform`, maintaining consistency with the other changes.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation