### PR TITLE
chore: rollback publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,49 +91,8 @@ jobs:
       - name: Install app dependencies and build web
         run: pnpm install --frozen-lockfile
 
-      - name: Set up SSH agent for private repository clone
-        if: matrix.target != 'i686-pc-windows-msvc'
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      - name: Add Git server to known hosts
-        if: matrix.platform != 'windows-latest'
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          chmod 600 ~/.ssh/known_hosts
-      - name: Pizza engine features setup
-        if: matrix.target != 'i686-pc-windows-msvc'
-        run: |
-          make add-dep-pizza-engine
-
-      - name: Build the app with ${{ matrix.platform }}
-        uses: tauri-apps/tauri-action@v0
-        if: matrix.target != 'i686-pc-windows-msvc'
-        env:
-          CI: false
-          PLATFORM: ${{ matrix.platform }}
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ""
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        with:
-          tagName: ${{ github.ref_name }}
-          releaseName: Coco ${{ needs.create-release.outputs.APP_VERSION }}
-          releaseBody: ""
-          releaseDraft: true
-          prerelease: false
-          args: --target ${{ matrix.target }} --features use_pizza_engine
-
       - name: Build the app with ${{ matrix.platform }} (windows i686 only)
         uses: tauri-apps/tauri-action@v0
-        if: matrix.target == 'i686-pc-windows-msvc'
         env:
           CI: false
           PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,51 @@ jobs:
       - name: Install app dependencies and build web
         run: pnpm install --frozen-lockfile
 
+      - name: Set up SSH agent for private repository clone
+        if: matrix.target != 'i686-pc-windows-msvc'
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Add Git server to known hosts
+        if: matrix.platform != 'windows-latest'
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Pizza engine features setup
+        if: matrix.target != 'i686-pc-windows-msvc'
+        run: |
+          make add-dep-pizza-engine
+          rustup target add ${{ matrix.target}} --toolchain nightly-2025-02-28 
+
+      - name: Build the app with ${{ matrix.platform }}
+        uses: tauri-apps/tauri-action@v0
+        if: matrix.target != 'i686-pc-windows-msvc'
+        env:
+          CI: false
+          PLATFORM: ${{ matrix.platform }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ""
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: Coco ${{ needs.create-release.outputs.APP_VERSION }}
+          releaseBody: ""
+          releaseDraft: true
+          prerelease: false
+          args: --target ${{ matrix.target }} --features use_pizza_engine
+
       - name: Build the app with ${{ matrix.platform }} (windows i686 only)
         uses: tauri-apps/tauri-action@v0
+        if: matrix.target == 'i686-pc-windows-msvc'
         env:
           CI: false
           PLATFORM: ${{ matrix.platform }}


### PR DESCRIPTION
## What does this PR do
This pull request simplifies the GitHub Actions workflow for the release process by removing redundant steps and consolidating the build process. The most notable change is the removal of setup steps and build configurations that were previously applied to non-Windows targets.

### Workflow simplification:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L94-L136): Removed multiple steps related to SSH setup, adding Git server to known hosts, and configuring the "Pizza engine" for non-Windows targets. These steps are no longer necessary, which reduces complexity in the workflow.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L94-L136): Consolidated the build process by retaining only the step for building the app on the `i686-pc-windows-msvc` target, streamlining the workflow.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation