### PR TITLE
fix: rustup for i688

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,10 +105,14 @@ jobs:
           chmod 600 ~/.ssh/known_hosts
 
       - name: Pizza engine features setup
-        if: matrix.target != 'i686-pc-windows-msvc'
         run: |
-          make add-dep-pizza-engine
-          rustup target add ${{ matrix.target}} --toolchain nightly-2025-02-28 
+          if [[ ${{ matrix.target }} == "i686-pc-windows-msvc" ]]; then
+             rustup target add i686-pc-windows-msvc --toolchain stable
+          else
+            make add-dep-pizza-engine-linux
+            rustup target add ${{ matrix.target}} --toolchain nightly-2025-02-28
+          fi
+          
 
       - name: Build the app with ${{ matrix.platform }}
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
## What does this PR do
This pull request updates the `.github/workflows/release.yml` file to refine the setup process for building the app across different target platforms. The most important change is the conditional logic added to handle platform-specific dependencies.

### Workflow improvements:

* Updated the "Pizza engine features setup" step to include conditional logic for platform-specific dependency installation. For the `i686-pc-windows-msvc` target, it now adds the required Rust target using `rustup`. For other platforms, it runs `make add-dep-pizza-engine-linux` and adds the target using a nightly toolchain.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation