### PR TITLE
chore: set log level to coco_lib=trace for built Coco app

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -585,6 +585,12 @@ fn set_up_tauri_logger() -> TauriPlugin<tauri::Wry> {
         builder
     }
 
+    // When running the built binary, set `COCO_LOG` to `coco_lib=trace` to capture all logs
+    // that come from Coco in the log file, which helps with debugging.
+    if !tauri::is_dev() {
+        std::env::set_var("COCO_LOG", "coco_lib=trace");
+    }
+
     let mut builder = tauri_plugin_log::Builder::new();
     builder = builder.format(|out, message, record| {
         let now = chrono::Local::now().format("%m-%d %H:%M:%S");


### PR DESCRIPTION
## What does this PR do

The default log level "info" won't help with debugging, so for **end users** who won't modify the environment variable `COCO_LOG`, their log file will not contain information useful for development.

Setting `COCO_LOG` to `coco_lib=trace` for the built applications (built via `pnpm tauri build`) so that we can capture all the Coco app logs in the log file. This won't affect development, one can always set the `COCO_LOG` variable in the command line to control the log level.
 
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation