### PR TITLE
refactor: execute Calculator/Extension search() in spawn_blocking

### DIFF
--- a/src-tauri/src/search/mod.rs
+++ b/src-tauri/src/search/mod.rs
@@ -32,7 +32,7 @@ fn same_type_futures(
     timeout_duration: Duration,
     search_query: SearchQuery,
 ) -> impl Future<
-    Output=(
+    Output = (
         QuerySource,
         Result<Result<QueryResponse, SearchError>, Elapsed>,
     ),
@@ -44,7 +44,7 @@ fn same_type_futures(
             timeout(timeout_duration, async {
                 query_source_trait_object.search(search_query).await
             })
-                .await,
+            .await,
         )
     }
 }


### PR DESCRIPTION
## What does this PR do

Run:

* `<CalculatorSource as SearchSource>::search()`
* `<ThirdPartyExtensionsSearchSource as SearchSource>::search()`

in the blocking Tokio thread pool using `tokio::task::spawn_blocking()` because 

1. they are blocking, i.e., no `.await`
2. they could take more than 100 microseconds, which could affect the async runtime scheduling according to the suggestions from [this post](https://ryhl.io/blog/async-what-is-blocking/#:~:text=a%20good%20rule%20of%20thumb%20is%20no%20more%20than%2010%20to%20100%20microseconds%20between%20each%20.await.):

    > To give a sense of scale of how much time is too much, a good rule of thumb is no more than 10 to 100 microseconds between each .await.

But querying the Coco cloud could still time out after this PR unless I set the timeout value to 800 milliseconds.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation