### PR TITLE
fix: new chat assistant id not found

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -18,6 +18,7 @@ Information about release notes of Coco Server is provided here.
 ### 🐛 Bug fix
 
 - fix: fixed issue with incorrect login status #600
+- fix: new chat assistant id not found #603
 
 ### ✈️ Improvements
 

--- a/src/hooks/useChatActions.ts
+++ b/src/hooks/useChatActions.ts
@@ -174,6 +174,7 @@ export function useChatActions(
       curIdRef.current = response?.payload?.id;
 
       newChat._source = {
+        ...response?.payload,
         message: value,
       };
       const updatedChat: Chat = {


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation