### PR TITLE
docs: remove the hyperlink in title

### DIFF
--- a/docs/content.en/docs/getting-started/installation/ubuntu.md
+++ b/docs/content.en/docs/getting-started/installation/ubuntu.md
@@ -14,7 +14,9 @@ asciinema: true
 [if_x11]: https://unix.stackexchange.com/q/202891/498440
 
 
-## Goto [https://coco.rs/](https://coco.rs/)
+## Go to the download page
+
+Download page: [link](https://coco.rs/#install)
 
 ## Download the package
 


### PR DESCRIPTION
## What does this PR do

Corrects the Ubuntu installation doc.

# Before:

<img width="559" alt="Screenshot 2025-06-05 at 6 23 47 PM" src="https://github.com/user-attachments/assets/af574e69-4d1b-4d2e-84a4-c7c77a7662c6" />

-----

# After:

<img width="559" alt="Screenshot 2025-06-05 at 6 24 07 PM" src="https://github.com/user-attachments/assets/1d2aa303-33e6-4841-9349-880ba4607938" />


## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation