### PR TITLE
chore: more logs for the setup process

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -35,6 +35,7 @@ Information about release notes of Coco Server is provided here.
 ### ✈️ Improvements
 
 - chore: initialize current assistant from history #606
+- chore: more logs for the setup process #634
 
 ## 0.5.1 (2025-05-31)
 

--- a/src-tauri/src/autostart.rs
+++ b/src-tauri/src/autostart.rs
@@ -4,7 +4,7 @@ use tauri::{Manager, Runtime};
 use tauri_plugin_autostart::ManagerExt;
 
 /// If the state reported from the OS and the state stored by us differ, our state is
-/// prioritized. Update the OS state to make them consistent.
+/// prioritized and seen as the correct one. Update the OS state to make them consistent.
 pub fn ensure_autostart_state_consistent(app: &mut tauri::App) -> Result<(), String> {
     let autostart_manager = app.autolaunch();
 
@@ -30,8 +30,11 @@ pub fn ensure_autostart_state_consistent(app: &mut tauri::App) -> Result<(), Str
                 log::info!("inconsistent autostart states fixed");
             }
             Err(e) => {
-              log::error!("failed to fix inconsistent autostart state due to error [{}]", e);
-              return Err(e.to_string());
+                log::error!(
+                    "failed to fix inconsistent autostart state due to error [{}]",
+                    e
+                );
+                return Err(e.to_string());
             }
         }
     }

--- a/src-tauri/src/autostart.rs
+++ b/src-tauri/src/autostart.rs
@@ -3,38 +3,40 @@ use std::{fs::create_dir, io::Read};
 use tauri::{Manager, Runtime};
 use tauri_plugin_autostart::ManagerExt;
 
-// Start or stop according to configuration
-pub fn enable_autostart(app: &mut tauri::App) {
-    use tauri_plugin_autostart::MacosLauncher;
-    use tauri_plugin_autostart::ManagerExt;
-
-    app.handle()
-        .plugin(tauri_plugin_autostart::init(
-            MacosLauncher::AppleScript,
-            None,
-        ))
-        .unwrap();
-
+/// If the state reported from the OS and the state stored by us differ, our state is
+/// prioritized. Update the OS state to make them consistent.
+pub fn ensure_autostart_state_consistent(app: &mut tauri::App) -> Result<(), String> {
     let autostart_manager = app.autolaunch();
 
-    // close autostart
-    // autostart_manager.disable().unwrap();
-    // return;
+    let os_state = autostart_manager.is_enabled().map_err(|e| e.to_string())?;
+    let coco_stored_state = current_autostart(app.app_handle()).map_err(|e| e.to_string())?;
 
-    match (
-        autostart_manager.is_enabled(),
-        current_autostart(app.app_handle()),
-    ) {
-        (Ok(false), Ok(true)) => match autostart_manager.enable() {
-            Ok(_) => println!("Autostart enabled successfully."),
-            Err(err) => eprintln!("Failed to enable autostart: {}", err),
-        },
-        (Ok(true), Ok(false)) => match autostart_manager.disable() {
-            Ok(_) => println!("Autostart disable successfully."),
-            Err(err) => eprintln!("Failed to disable autostart: {}", err),
-        },
-        _ => (),
+    if os_state != coco_stored_state {
+        log::warn!(
+            "autostart inconsistent states, OS state [{}], Coco state [{}], config file could be deleted or corrupted",
+            os_state,
+            coco_stored_state
+        );
+        log::info!("trying to correct the inconsistent states");
+
+        let result = if coco_stored_state {
+            autostart_manager.enable()
+        } else {
+            autostart_manager.disable()
+        };
+
+        match result {
+            Ok(_) => {
+                log::info!("inconsistent autostart states fixed");
+            }
+            Err(e) => {
+              log::error!("failed to fix inconsistent autostart state due to error [{}]", e);
+              return Err(e.to_string());
+            }
+        }
     }
+
+    Ok(())
 }
 
 fn current_autostart<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<bool, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,8 +19,6 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 use tauri::async_runtime::block_on;
 use tauri::plugin::TauriPlugin;
-#[cfg(target_os = "macos")]
-use tauri::ActivationPolicy;
 use tauri::{
     AppHandle, Emitter, Manager, PhysicalPosition, Runtime, WebviewWindow, Window, WindowEvent,
 };
@@ -163,6 +161,13 @@ pub fn run() {
             crate::common::document::open,
         ])
         .setup(|app| {
+            #[cfg(target_os = "macos")]
+            {
+                log::trace!("hiding Dock icon on macOS");
+                app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+                log::trace!("Dock icon should be hidden now");
+            }
+
             let app_handle = app.handle().clone();
             GLOBAL_TAURI_APP_HANDLE
                 .set(app_handle.clone())
@@ -181,13 +186,6 @@ pub fn run() {
             shortcut::enable_shortcut(app);
 
             ensure_autostart_state_consistent(app)?;
-
-            #[cfg(target_os = "macos")]
-            {
-                log::trace!("hiding Dock icon on macOS");
-                app.set_dock_visibility(false);
-                log::trace!("Dock icon should be hidden now");
-            }
 
             // app.listen("theme-changed", move |event| {
             //     if let Ok(payload) = serde_json::from_str::<ThemeChangedPayload>(event.payload()) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,7 +13,7 @@ use crate::common::register::SearchSourceRegistry;
 // use crate::common::traits::SearchSource;
 use crate::common::{MAIN_WINDOW_LABEL, SETTINGS_WINDOW_LABEL};
 use crate::server::servers::{load_or_insert_default_server, load_servers_token};
-use autostart::{change_autostart, enable_autostart};
+use autostart::{change_autostart, ensure_autostart_state_consistent};
 use lazy_static::lazy_static;
 use std::sync::Mutex;
 use std::sync::OnceLock;
@@ -64,6 +64,8 @@ pub fn run() {
     let ctx = tauri::generate_context!();
 
     let mut app_builder = tauri::Builder::default();
+    // Set up logger first
+    app_builder = app_builder.plugin(set_up_tauri_logger());
 
     #[cfg(desktop)]
     {
@@ -77,7 +79,7 @@ pub fn run() {
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_autostart::init(
-            MacosLauncher::AppleScript,
+            MacosLauncher::LaunchAgent,
             None,
         ))
         .plugin(tauri_plugin_deep_link::init())
@@ -88,8 +90,7 @@ pub fn run() {
         .plugin(tauri_plugin_screenshots::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_windows_version::init())
-        .plugin(set_up_tauri_logger());
+        .plugin(tauri_plugin_windows_version::init());
 
     // Conditional compilation for macOS
     #[cfg(target_os = "macos")]
@@ -166,6 +167,7 @@ pub fn run() {
             GLOBAL_TAURI_APP_HANDLE
                 .set(app_handle.clone())
                 .expect("variable already initialized");
+            log::trace!("global Tauri app handle set");
 
             let registry = SearchSourceRegistry::default();
 
@@ -178,10 +180,14 @@ pub fn run() {
 
             shortcut::enable_shortcut(app);
 
-            enable_autostart(app);
+            ensure_autostart_state_consistent(app)?;
 
             #[cfg(target_os = "macos")]
-            app.set_activation_policy(ActivationPolicy::Accessory);
+            {
+                log::trace!("hiding Dock icon on macOS");
+                app.set_dock_visibility(false);
+                log::trace!("Dock icon should be hidden now");
+            }
 
             // app.listen("theme-changed", move |event| {
             //     if let Ok(payload) = serde_json::from_str::<ThemeChangedPayload>(event.payload()) {
@@ -261,7 +267,7 @@ pub async fn init<R: Runtime>(app_handle: &AppHandle<R>) {
             .await;
     }
 
-    extension::built_in::pizza_engine_runtime::start_pizza_engine_runtime();
+    extension::built_in::pizza_engine_runtime::start_pizza_engine_runtime().await;
 }
 
 #[tauri::command]

--- a/src-tauri/src/setup/mac.rs
+++ b/src-tauri/src/setup/mac.rs
@@ -1,5 +1,5 @@
 //credits to: https://github.com/ayangweb/ayangweb-EcoPaste/blob/169323dbe6365ffe4abb64d867439ed2ea84c6d1/src-tauri/src/core/setup/mac.rs
-use tauri::{ActivationPolicy, App, Emitter, EventTarget, WebviewWindow};
+use tauri::{App, Emitter, EventTarget, WebviewWindow};
 use tauri_nspanel::{cocoa::appkit::NSWindowCollectionBehavior, panel_delegate, WebviewWindowExt};
 
 use crate::common::MAIN_WINDOW_LABEL;
@@ -12,9 +12,7 @@ const WINDOW_BLUR_EVENT: &str = "tauri://blur";
 const WINDOW_MOVED_EVENT: &str = "tauri://move";
 const WINDOW_RESIZED_EVENT: &str = "tauri://resize";
 
-pub fn platform(app: &mut App, main_window: WebviewWindow, _settings_window: WebviewWindow) {
-    app.set_activation_policy(ActivationPolicy::Accessory);
-
+pub fn platform(_app: &mut App, main_window: WebviewWindow, _settings_window: WebviewWindow) {
     // Convert ns_window to ns_panel
     let panel = main_window.to_panel().unwrap();
 

--- a/src-tauri/src/shortcut.rs
+++ b/src-tauri/src/shortcut.rs
@@ -17,6 +17,7 @@ const DEFAULT_SHORTCUT: &str = "ctrl+shift+space";
 
 /// Set up the shortcut upon app start.
 pub fn enable_shortcut(app: &App) {
+    log::trace!("setting up Coco hotkey");
     let store = app
         .store(COCO_TAURI_STORE)
         .expect("creating a store should not fail");
@@ -43,6 +44,7 @@ pub fn enable_shortcut(app: &App) {
             .expect("default shortcut should never be invalid");
         _register_shortcut_upon_start(app, default_shortcut);
     }
+    log::trace!("Coco hotkey has been set");
 }
 
 /// Get the stored shortcut as a string, same as [`_get_shortcut()`], except that


### PR DESCRIPTION
## What does this PR do

* Add more logs for the `setup()` hook
* Refactor the `enable_autostart()` (renamed to `ensure_autostart_state_consistent()`) function to make its semantic more clear

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation