### PR TITLE
fix: input lost when reopening dialog after search

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -33,6 +33,7 @@ Information about release notes of Coco Server is provided here.
 - fix: fix ai overview hidden height before message #622
 - fix: tab key hides window in chat mode #641
 - fix: arrow keys still navigated search when menu opened with Cmd+K #642
+- fix: input lost when reopening dialog after search #644
 
 ### ✈️ Improvements
 

--- a/src/components/Search/MCPPopover.tsx
+++ b/src/components/Search/MCPPopover.tsx
@@ -246,6 +246,7 @@ export default function MCPPopover({
 
                     <PopoverInput
                       autoFocus
+                      value={keyword}
                       ref={searchInputRef}
                       className="size-full px-2 rounded-lg border dark:border-white/10 bg-transparent"
                       onChange={(e) => {

--- a/src/components/Search/SearchPopover.tsx
+++ b/src/components/Search/SearchPopover.tsx
@@ -251,6 +251,7 @@ export default function SearchPopover({
 
                     <PopoverInput
                       autoFocus
+                      value={keyword}
                       ref={searchInputRef}
                       className="size-full px-2 rounded-lg border dark:border-white/10 bg-transparent"
                       onChange={(e) => {


### PR DESCRIPTION
## What does this PR do
<img width="500" alt="image" src="https://github.com/user-attachments/assets/3907edd8-c5ee-4b34-83e0-7d369e8c0196" />

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation