### PR TITLE
refactor: check if the message block is purely blank

### DIFF
--- a/src/hooks/useStreamChat.ts
+++ b/src/hooks/useStreamChat.ts
@@ -63,7 +63,7 @@ export const useStreamChat = (options: Options) => {
           }
 
           // If the chunk data does not contain a message_chunk, we ignore it
-          if (chunkData.message_chunk) {
+          if (chunkData.message_chunk.trim()) {
             setVisible(true);
           }
 


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation