### PR TITLE
refactor: blocking the default behavior of the tab key

### DIFF
--- a/src/commands/servers.ts
+++ b/src/commands/servers.ts
@@ -29,6 +29,7 @@ const WHITELIST_SERVERS = [
   "refresh_coco_server_info",
   "handle_sso_callback",
   "query_coco_fusion",
+  "open_session_chat", // TODO: quick ai access is a configured service, even if the current service is not logged in, it should not affect the configured service.
 ];
 
 async function invokeWithErrorHandler<T>(
@@ -50,7 +51,7 @@ async function invokeWithErrorHandler<T>(
       const failedResult = result as any;
       if (failedResult.failed?.length > 0 && failedResult?.hits?.length == 0) {
         failedResult.failed.forEach((error: any) => {
-          addError(error.error, 'error');
+          addError(error.error, "error");
           // console.error(error.error);
         });
       }

--- a/src/components/Search/AssistantManager.tsx
+++ b/src/components/Search/AssistantManager.tsx
@@ -7,7 +7,6 @@ import platformAdapter from "@/utils/platformAdapter";
 import { Get } from "@/api/axiosRequest";
 import type { Assistant } from "@/types/chat";
 import { useAppStore } from "@/stores/appStore";
-import { useKeyPress } from "ahooks";
 
 interface AssistantManagerProps {
   isChatMode: boolean;
@@ -86,8 +85,16 @@ export function useAssistantManager({
       return setGoAskAi(false);
     }
 
-    if (key === "Tab" && isTauri && isChatMode) {
-      return e.preventDefault();
+    if (key === "Tab" && isTauri) {
+      e.preventDefault();
+
+      if (isChatMode) {
+        return;
+      }
+
+      assistant_get();
+
+      return handleAskAi();
     }
 
     if (key === "Enter" && !shiftKey && !isChatMode && isTauri) {
@@ -100,22 +107,6 @@ export function useAssistantManager({
       handleSubmit();
     }
   };
-
-  useKeyPress(
-    "tab",
-    (event) => {
-      if (!isTauri || isChatMode) return;
-
-      event.preventDefault();
-
-      assistant_get();
-
-      handleAskAi();
-    },
-    {
-      exactMatch: true,
-    }
-  );
 
   return {
     askAI,

--- a/src/components/Search/AssistantManager.tsx
+++ b/src/components/Search/AssistantManager.tsx
@@ -65,12 +65,16 @@ export function useAssistantManager({
 
     if (!askAIRef.current) return;
 
-    const value = inputValue.trim();
+    let value = inputValue.trim();
 
-    if (!selectedAssistant && isEmpty(value)) return;
+    if (isEmpty(value)) return;
+
+    if (!goAskAi && selectedAssistant) {
+      value = "";
+    }
 
     changeInput("");
-    setAskAiMessage(!goAskAi && selectedAssistant ? "" : value);
+    setAskAiMessage(value);
     setGoAskAi(true);
   };
 

--- a/src/components/Search/AssistantManager.tsx
+++ b/src/components/Search/AssistantManager.tsx
@@ -103,8 +103,10 @@ export function useAssistantManager({
 
   useKeyPress(
     "tab",
-    () => {
+    (event) => {
       if (!isTauri || isChatMode) return;
+
+      event.preventDefault();
 
       assistant_get();
 

--- a/src/components/Search/AutoResizeTextarea.tsx
+++ b/src/components/Search/AutoResizeTextarea.tsx
@@ -9,13 +9,14 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 
-import { specialCharacterFiltering } from "@/utils/index"
+import { specialCharacterFiltering } from "@/utils/index";
 
 const LINE_HEIGHT = 24; // 1.5rem
 const MAX_FIRST_LINE_WIDTH = 470; // Width in pixels for first line
 const MAX_HEIGHT = 240; // 15rem
 
 interface AutoResizeTextareaProps {
+  isChatMode: boolean;
   input: string;
   setInput: (value: string) => void;
   handleKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
@@ -31,6 +32,7 @@ const AutoResizeTextarea = forwardRef<
 >(
   (
     {
+      isChatMode,
       input,
       setInput,
       handleKeyDown,
@@ -135,7 +137,7 @@ const AutoResizeTextarea = forwardRef<
 
     const handleChange = useCallback(
       (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-        const value = specialCharacterFiltering(e.target.value)
+        const value = specialCharacterFiltering(e.target.value);
         setInput(value);
       },
       [setInput]
@@ -144,6 +146,7 @@ const AutoResizeTextarea = forwardRef<
     return (
       <textarea
         ref={textareaRef}
+        id={isChatMode ? "chat-textarea" : "search-textarea"}
         autoFocus
         autoComplete="off"
         autoCapitalize="none"

--- a/src/components/Search/InputBox.tsx
+++ b/src/components/Search/InputBox.tsx
@@ -288,6 +288,7 @@ export default function ChatInput({
     >
       <AutoResizeTextarea
         ref={textareaRef}
+        isChatMode={isChatMode}
         input={inputValue}
         setInput={handleInputChange}
         handleKeyDown={handleKeyDownAutoResizeTextarea}

--- a/src/utils/tauriAdapter.ts
+++ b/src/utils/tauriAdapter.ts
@@ -236,6 +236,12 @@ export const createTauriAdapter = (): TauriPlatformAdapter => {
       const { invoke } = await import("@tauri-apps/api/core");
 
       if (data.type === "AI Assistant") {
+        const textarea = document.querySelector("#search-textarea");
+
+        if (!(textarea instanceof HTMLTextAreaElement)) return;
+
+        textarea.focus();
+
         const event = new KeyboardEvent("keydown", {
           key: "Tab",
           code: "Tab",
@@ -245,7 +251,7 @@ export const createTauriAdapter = (): TauriPlatformAdapter => {
           cancelable: true,
         });
 
-        return window.dispatchEvent(event);
+        return textarea.dispatchEvent(event);
       }
 
       const hideCoco = () => {


### PR DESCRIPTION
## What does this PR do
<img width="492" alt="image" src="https://github.com/user-attachments/assets/c67771f8-f86e-4ed3-8ffe-5dcf34842196" />
<img width="687" alt="image" src="https://github.com/user-attachments/assets/27232372-12ed-42a4-8829-fc9642b644db" />

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation