### PR TITLE
fix: no make target with project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
           if [[ ${{ matrix.target }} == "i686-pc-windows-msvc" ]]; then
              rustup target add i686-pc-windows-msvc --toolchain stable
           else
-            make add-dep-pizza-engine-linux
+            ( cd src-tauri && cargo add --git ssh://git@github.com/infinilabs/pizza.git pizza-engine --features query_string_parser,persistence )
             rustup target add ${{ matrix.target}} --toolchain nightly-2025-02-28
           fi
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
           version: latest
 
       - name: Install rust target
+        if: matrix.target == 'i686-pc-windows-msvc'
         run: rustup target add ${{ matrix.target }}
 
       - name: Install dependencies (ubuntu only)
@@ -105,15 +106,12 @@ jobs:
           chmod 600 ~/.ssh/known_hosts
 
       - name: Pizza engine features setup
+        working-directory: src-tauri
+        if: matrix.target != 'i686-pc-windows-msvc'
         run: |
-          if [[ ${{ matrix.target }} == "i686-pc-windows-msvc" ]]; then
-             rustup target add i686-pc-windows-msvc --toolchain stable
-          else
-            ( cd src-tauri && cargo add --git ssh://git@github.com/infinilabs/pizza.git pizza-engine --features query_string_parser,persistence )
-            rustup target add ${{ matrix.target}} --toolchain nightly-2025-02-28
-          fi
-          
-
+          rustup target add ${{ matrix.target }}
+          (cd .. && make add-dep-pizza-engine)
+                    
       - name: Build the app with ${{ matrix.platform }}
         uses: tauri-apps/tauri-action@v0
         if: matrix.target != 'i686-pc-windows-msvc'


### PR DESCRIPTION
## What does this PR do
This pull request updates the `.github/workflows/release.yml` file to modify how dependencies are added for non-Windows targets during the release workflow.

### Changes to dependency management:
* Replaced the `make add-dep-pizza-engine-linux` command with a direct `cargo add` command to add the `pizza-engine` dependency from a Git repository. This change also specifies additional features (`query_string_parser` and `persistence`) to be included when adding the dependency. (`[.github/workflows/release.ymlL112-R112](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L112-R112)`)
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation