### PR TITLE
fix: toggle extension should register/unregister hotkey

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -16,6 +16,7 @@ Information about release notes of Coco Server is provided here.
 ### 🐛 Bug fix
 
 - fix: quick ai state synchronous #693
+- fix: toggle extension should register/unregister hotkey #691
 
 ### ✈️ Improvements
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -845,6 +845,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "applications",
+ "async-recursion",
  "async-trait",
  "base64 0.13.1",
  "borrowme",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -100,6 +100,7 @@ function_name = "0.3.0"
 regex = "1.11.1"
 borrowme = "0.0.15"
 tauri-plugin-opener = "2"
+async-recursion = "1.1.1"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2" }

--- a/src-tauri/src/extension/built_in/application/without_feature.rs
+++ b/src-tauri/src/extension/built_in/application/without_feature.rs
@@ -12,7 +12,7 @@ pub(crate) const QUERYSOURCE_ID_DATASOURCE_ID_DATASOURCE_NAME: &str = "Applicati
 pub struct ApplicationSearchSource;
 
 impl ApplicationSearchSource {
-    pub async fn init<R: Runtime>(_app_handle: AppHandle<R>) -> Result<(), String> {
+    pub async fn prepare_index_and_store<R: Runtime>(_app_handle: AppHandle<R>) -> Result<(), String> {
         Ok(())
     }
 }
@@ -116,4 +116,15 @@ pub async fn get_app_metadata<R: Runtime>(
     _app_path: String,
 ) -> Result<AppMetadata, String> {
     unreachable!("app list should be empty, there is no way this can be invoked")
+}
+
+
+pub(crate) fn set_apps_hotkey<R: Runtime>(_tauri_app_handle: &AppHandle<R>) -> Result<(), String> {
+    // no-op
+    Ok(())
+}
+
+pub(crate) fn unset_apps_hotkey<R: Runtime>(_tauri_app_handle: &AppHandle<R>) -> Result<(), String> {
+    // no-op
+    Ok(())
 }


### PR DESCRIPTION
## What does this PR do

Before this PR, when an extension was disabled, its registered hotkey would still work, which should not happen since the extension is disabled. This PR fixes the issue.

Also, disabled extensions can no longer be modified and will appear grayed out in the settings page:

<img width="1112" alt="Screenshot 2025-06-17 at 4 13 51 PM" src="https://github.com/user-attachments/assets/6691d096-6e26-4096-9afb-d7148c422ca1" />


## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation