### PR TITLE
fix: take coco server back on refresh

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -17,6 +17,7 @@ Information about release notes of Coco Server is provided here.
 
 - fix: quick ai state synchronous #693
 - fix: toggle extension should register/unregister hotkey #691
+- fix: take coco server back on refresh #696
 
 ### ✈️ Improvements
 


### PR DESCRIPTION
## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation