### PR TITLE
chore: typo step name and env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,6 @@ jobs:
             target: "aarch64-unknown-linux-gnu"
     env:
       APP_VERSION: ${{ needs.create-release.outputs.APP_VERSION }}
-      RELEASE_BODY: ${{ needs.create-release.outputs.RELEASE_BODY }}
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -107,7 +106,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
 
-      - name: Add Rust build target at ${{ matrix.platform}} for ${{ matrix.target }}
+      - name: Add Rust build target
         working-directory: src-tauri
         shell: bash
         run: |
@@ -158,7 +157,7 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: Coco ${{ env.APP_VERSION }}
-          releaseBody: "${{ env.RELEASE_BODY }}"
+          releaseBody: "${{ needs.create-release.outputs.RELEASE_BODY }}"
           releaseDraft: true
           prerelease: false
           args: ${{ env.BUILD_ARGS }}


### PR DESCRIPTION
## What does this PR do
chore: typo step name and remove too long env value
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation