### PR TITLE
refactor: change File Search ext type to extension

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -20,6 +20,7 @@ Information about release notes of Coco Server is provided here.
 
 ### ✈️ Improvements
 - refactor: prioritize stat(2) when checking if a file is dir #737
+- refactor: change File Search ext type to extension #738
 
 ## 0.6.0 (2025-06-29)
 

--- a/src-tauri/src/extension/built_in/file_search.rs
+++ b/src-tauri/src/extension/built_in/file_search.rs
@@ -27,7 +27,7 @@ pub(crate) const PLUGIN_JSON_FILE: &str = r#"
   "platforms": ["macos"],
   "description": "Search files on your system using macOS Spotlight",
   "icon": "font_Filesearch",
-  "type": "command",
+  "type": "extension",
   "enabled": true
 }
 "#;


### PR DESCRIPTION
## What does this PR do

1. In the `list_extensions(filter)` interface, if no filter is performed, don't do the extensions cleanup.
2. Change the extension type of "File Search" to "Extension"

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation