### PR TITLE
fix(file search): searching by name&content does not search file name

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -18,6 +18,7 @@ Information about release notes of Coco Server is provided here.
 
 ### 🐛 Bug fix
 - fix(file search): apply filters before from/size parameters #741
+- fix(file search): searching by name&content does not search file name #743
 
 ### ✈️ Improvements
 

--- a/src-tauri/src/extension/built_in/file_search.rs
+++ b/src-tauri/src/extension/built_in/file_search.rs
@@ -235,7 +235,10 @@ impl FileSearchExtensionSearchSource {
                 args.push(format!("kMDItemFSName == '*{}*'", query_string));
             }
             SearchBy::NameAndContents => {
-                args.push(format!("kMDItemTextContent == '{}'", query_string));
+                args.push(format!(
+                    "kMDItemFSName == '*{}*' || kMDItemTextContent == '{}'",
+                    query_string, query_string
+                ));
             }
         }
 


### PR DESCRIPTION
## What does this PR do

Fix the issue that searching with the `SearchBy::NameAndContent` parameter will only search by file content

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation