### PR TITLE
chore: replace meval-rs with our fork to clear dep warning

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of Coco Server is provided here.
 - refactor: change File Search ext type to extension #738
 - refactor: create chat & send chat api #739
 - chore: icon support for more file types #740
+- chore: replace meval-rs with our fork to clear dep warning #745
 
 ## 0.6.0 (2025-06-29)
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3511,11 +3511,10 @@ dependencies = [
 [[package]]
 name = "meval"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79496a5651c8d57cd033c5add8ca7ee4e3d5f7587a4777484640d9cb60392d9"
+source = "git+https://github.com/infinilabs/meval-rs#8113cdae751b7ca060d28a08ecbfbcededfd4304"
 dependencies = [
  "fnv",
- "nom 1.2.4",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -3686,18 +3685,21 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
-
-[[package]]
-name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -87,7 +87,7 @@ http = "1.1.0"
 tungstenite = "0.24.0"
 tokio-util = "0.7.14"
 tauri-plugin-windows-version = "2"
-meval = "0.2"
+meval = { git = "https://github.com/infinilabs/meval-rs" }
 chinese-number = "0.7"
 num2words = "1"
 tauri-plugin-log = "2"


### PR DESCRIPTION
This commit replaces the meval-rs dependency with our [fork](https://github.com/infinilabs/meval-rs). The original meval-rs crate has not been maintained for a long time and uses nom 1.0, a crate that was released 9 years ago, which would be rejected by future Rust compiler because it contains outdated Rust syntaxes. This is the reason why we are seeing the following warning:

```
warning: the following packages contain code that will be rejected by a future version of Rust: nom v1.2.4
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1
```

Switching to our fork would solve this warning.

## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation