### PR TITLE
refactor: adjust extension code hierarchy

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -27,6 +27,7 @@ Information about release notes of Coco Server is provided here.
 - refactor: create chat & send chat api #739
 - chore: icon support for more file types #740
 - chore: replace meval-rs with our fork to clear dep warning #745
+- refactor: adjust extension code hierarchy #747
 
 ## 0.6.0 (2025-06-29)
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@ name = "coco"
 version = "0.6.0"
 description = "Search, connect, collaborate – all in one place."
 authors = ["INFINI Labs"]
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/src-tauri/rust-toolchain.toml
+++ b/src-tauri/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-06-06"
+channel = "nightly-2025-06-26"

--- a/src-tauri/src/extension/mod.rs
+++ b/src-tauri/src/extension/mod.rs
@@ -1,6 +1,5 @@
 pub(crate) mod built_in;
-pub(crate) mod store;
-mod third_party;
+pub(crate) mod third_party;
 
 use crate::common::document::OnOpened;
 use crate::{common::register::SearchSourceRegistry, GLOBAL_TAURI_APP_HANDLE};
@@ -56,7 +55,9 @@ pub struct Extension {
     platforms: Option<HashSet<Platform>>,
     /// Extension description.
     description: String,
-    //// Specify the icon for this extension, multi options are available:
+    //// Specify the icon for this extension, 
+    /// 
+    /// For the `plugin.json` file, this field can be specified in multi options:
     ///
     /// 1. It can be a path to the icon file, the path can be
     ///
@@ -68,6 +69,11 @@ pub struct Extension {
     /// In cases where your icon file is named similarly to a font class code, Coco
     /// will treat it as an icon file if it exists, i.e., if file `<extension>/assets/font_coco`
     /// exists, then Coco will use this file rather than the built-in 'font_coco' icon.
+    /// 
+    /// For the `struct Extension` loaded into memory, this field should be:
+    /// 
+    /// 1. An absolute path
+    /// 2. A font code
     icon: String,
     r#type: ExtensionType,
     /// If this is a Command extension, then action defines the operation to execute
@@ -501,7 +507,7 @@ pub(crate) async fn init_extensions(mut extensions: Vec<Extension>) -> Result<()
 
     // extension store
     search_source_registry_tauri_state
-        .register_source(store::ExtensionStore)
+        .register_source(third_party::store::ExtensionStore)
         .await;
 
     // Init the built-in enabled extensions

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -159,9 +159,9 @@ pub fn run() {
             extension::register_extension_hotkey,
             extension::unregister_extension_hotkey,
             extension::is_extension_enabled,
-            extension::store::search_extension,
-            extension::store::install_extension,
-            extension::store::uninstall_extension,
+            extension::third_party::store::search_extension,
+            extension::third_party::store::install_extension_from_store,
+            extension::third_party::uninstall_extension,
             settings::set_allow_self_signature,
             settings::get_allow_self_signature,
             assistant::ask_ai,
@@ -607,7 +607,12 @@ fn set_up_tauri_logger() -> TauriPlugin<tauri::Wry> {
     // When running the built binary, set `COCO_LOG` to `coco_lib=trace` to capture all logs
     // that come from Coco in the log file, which helps with debugging.
     if !tauri::is_dev() {
-        std::env::set_var("COCO_LOG", "coco_lib=trace");
+       // We have absolutely no guarantee that we (We have control over the Rust 
+       // code, but definitely no idea about the libc C code, all the shared objects
+       // that we will link) will not concurrently read/write `envp`, so just use unsafe.
+       unsafe {
+          std::env::set_var("COCO_LOG", "coco_lib=trace");
+       }
     }
 
     let mut builder = tauri_plugin_log::Builder::new();

--- a/src/components/Search/ExtensionStore.tsx
+++ b/src/components/Search/ExtensionStore.tsx
@@ -214,7 +214,7 @@ const ExtensionStore = () => {
 
       setInstallingExtensions(installingExtensions.concat(id));
 
-      await platformAdapter.invokeBackend("install_extension", { id });
+      await platformAdapter.invokeBackend("install_extension_from_store", { id });
 
       toggleInstall();
 


### PR DESCRIPTION
In this commit, I refactored the extension code structure.

* We can only install third-party extensions so the `store.rs` file should belong to the `third_party` directory.

* Move tauri command `uninstall_extension()` to `extension/mod.rs` from `third_party.rs` since one can uninstall an extension regardless of how you installed it.

* Refactor the `install_extension_from_store()` function, add more descriptive code comments.

Also, a trivial change, bump Rust toolchain and edition to use the [let-chains](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/#let-chains) syntax.


## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation