### PR TITLE
refactor: do status code check before deserializing response

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -39,6 +39,7 @@ Information about release notes of Coco Server is provided here.
 - chore: make optional fields optional #758
 - chore: search-chat components add formatUrl & think data & icons url #765
 - chore: Coco app http request headers #744
+- refactor: do status code check before deserializing response #767
 
 ## 0.6.0 (2025-06-29)
 

--- a/src-tauri/src/server/connector.rs
+++ b/src-tauri/src/server/connector.rs
@@ -1,7 +1,8 @@
 use crate::common::connector::Connector;
 use crate::common::search::parse_search_results;
-use crate::server::http_client::HttpClient;
+use crate::server::http_client::{HttpClient, status_code_check};
 use crate::server::servers::get_all_servers;
+use http::StatusCode;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -107,6 +108,7 @@ pub async fn fetch_connectors_by_server(id: &str) -> Result<Vec<Connector>, Stri
             // dbg!("Error fetching connector for id {}: {}", &id, &e);
             format!("Error fetching connector: {}", e)
         })?;
+    status_code_check(&resp, &[StatusCode::OK, StatusCode::CREATED])?;
 
     // Parse the search results directly from the response body
     let datasource: Vec<Connector> = parse_search_results(resp)

--- a/src-tauri/src/server/http_client.rs
+++ b/src-tauri/src/server/http_client.rs
@@ -1,7 +1,7 @@
 use crate::server::servers::{get_server_by_id, get_server_token};
 use crate::util::app_lang::get_app_lang;
 use crate::util::platform::Platform;
-use http::{HeaderName, HeaderValue};
+use http::{HeaderName, HeaderValue, StatusCode};
 use once_cell::sync::Lazy;
 use reqwest::{Client, Method, RequestBuilder};
 use std::collections::HashMap;
@@ -283,5 +283,32 @@ impl HttpClient {
             None,
         )
         .await
+    }
+}
+
+/// Helper function to check status code.
+///
+/// If the status code is not in the `allowed_status_codes` list, return an error.
+pub(crate) fn status_code_check(
+    response: &reqwest::Response,
+    allowed_status_codes: &[StatusCode],
+) -> Result<(), String> {
+    let status_code = response.status();
+
+    if !allowed_status_codes.contains(&status_code) {
+        let msg = format!(
+            "Response of request [{}] status code failed: status code [{}], which is not in the 'allow' list {:?}",
+            response.url(),
+            status_code,
+            allowed_status_codes
+                .iter()
+                .map(|status| status.to_string())
+                .collect::<Vec<String>>()
+        );
+        log::warn!("{}", msg);
+
+        Err(msg)
+    } else {
+        Ok(())
     }
 }


### PR DESCRIPTION
This commit adds a status code check to the following requests, only when this check passes, we deserialize the response JSON body:

- get_connectors_by_server
- mcp_server_search
- datasource_search

A helper function `status_code_check(response, allowed_status_codes)` is added to make refactoring easier.

## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation