### PR TITLE
fix: indexing apps does not respect search scope config

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -24,6 +24,7 @@ Information about release notes of Coco Server is provided here.
 - fix(file search): searching by name&content does not search file name #743
 - fix: prevent window from hiding when moved on Windows #748
 - fix: unregister ext hotkey when it gets deleted #770
+- fix: indexing apps does not respect search scope config #773
 
 ### ✈️ Improvements
 


### PR DESCRIPTION
This commit fixes the issue that indexing applications does not respect the search scope configuration, it always uses the default values.

## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation