### PR TITLE
refactor: add border-radius to extended categories

### DIFF
--- a/src/components/Settings/Extensions/index.tsx
+++ b/src/components/Settings/Extensions/index.tsx
@@ -171,7 +171,7 @@ export const Extensions = () => {
           </div>
 
           <div className="flex justify-between gap-6 my-4">
-            <div className="flex h-8 border dark:border-gray-700">
+            <div className="flex h-8 border dark:border-gray-700 rounded-md overflow-hidden">
               {state.categories.map((item) => {
                 return (
                   <div


### PR DESCRIPTION
## What does this PR do

Before:
<img width="468" height="93" alt="image" src="https://github.com/user-attachments/assets/828467ae-8c4f-4476-95c0-657c67cf0512" />

After:
<img width="453" height="86" alt="image" src="https://github.com/user-attachments/assets/c952c74b-62b0-4553-a4e1-e2f85d07e804" />


## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation