### PR TITLE
refactor: separate user agreement and privacy policy links

### DIFF
--- a/src/components/Cloud/ServiceAuth.tsx
+++ b/src/components/Cloud/ServiceAuth.tsx
@@ -210,15 +210,31 @@ const ServiceAuth = memo(
               />
             )}
 
-            {/* Privacy Policy Link */}
-            <button
-              className="text-xs text-[#0096FB] dark:text-blue-400 block"
-              onClick={() =>
-                OpenURLWithBrowser(currentService?.provider?.privacy_policy)
-              }
-            >
-              {t("cloud.privacyPolicy")}
-            </button>
+            <div className="flex items-center gap-2">
+              {/* EULA Link */}
+              <button
+                className="text-xs text-[#0096FB] dark:text-blue-400 block"
+                onClick={() =>
+                  OpenURLWithBrowser(currentService?.provider?.eula)
+                }
+              >
+                {t("cloud.eula")}
+              </button>
+
+              <span className="text-xs text-[#0096FB] dark:text-blue-400 block">
+                |
+              </span>
+
+              {/* Privacy Policy Link */}
+              <button
+                className="text-xs text-[#0096FB] dark:text-blue-400 block"
+                onClick={() =>
+                  OpenURLWithBrowser(currentService?.provider?.privacy_policy)
+                }
+              >
+                {t("cloud.privacyPolicy")}
+              </button>
+            </div>
           </div>
         )}
       </div>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -459,7 +459,8 @@
     "login": "Login",
     "cancel": "Cancel",
     "copyUrl": "Copy URL",
-    "privacyPolicy": "EULA | Privacy Policy",
+    "eula": "EULA",
+    "privacyPolicy": "Privacy Policy",
     "connect": {
       "back": "Back",
       "title": "Connecting to Your Coco-Server",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -459,7 +459,8 @@
     "login": "登录",
     "cancel": "取消",
     "copyUrl": "复制链接",
-    "privacyPolicy": "用户协议 | 隐私政策",
+    "eula": "用户协议",
+    "privacyPolicy": "隐私政策",
     "connect": {
       "back": "返回",
       "title": "连接到您的 Coco-Server",


### PR DESCRIPTION
## What does this PR do

I’ve separated the links for the “User Agreement” and “Privacy Policy”, but the API still needs to provide the correct URLs.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation