### PR TITLE
chore: remove unused tauri cmd get_server_token

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -107,7 +107,6 @@ pub fn run() {
             show_settings,
             show_check,
             hide_check,
-            server::servers::get_server_token,
             server::servers::add_coco_server,
             server::servers::remove_coco_server,
             server::servers::list_coco_servers,

--- a/src/commands/servers.ts
+++ b/src/commands/servers.ts
@@ -72,10 +72,6 @@ async function invokeWithErrorHandler<T>(
   }
 }
 
-export function get_server_token(id: string): Promise<ServerTokenResponse> {
-  return invokeWithErrorHandler(`get_server_token`, { id });
-}
-
 export function list_coco_servers(): Promise<Server[]> {
   return invokeWithErrorHandler(`list_coco_servers`);
 }


### PR DESCRIPTION
## What does this PR do

Found this tauri command while reading the code, then I realized that
token management logic should all be kept in the backend, there is no
need to expose it to the frontend. And indeed, searching for it in the
frontend code showed that [it is not used at all](https://github.com/search?q=repo%3Ainfinilabs%2Fcoco-app+get_server_token+language%3ATypeScript&type=code&l=TypeScript).

```sh
$ cd src

$ rg get_server_token
commands/servers.ts
75:export function get_server_token(id: string): Promise<ServerTokenResponse> {
76:  return invokeWithErrorHandler(`get_server_token`, { id });
```

So remove it.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation