### PR TITLE
chore: remove unused type ServerTokenResponse

### DIFF
--- a/src/commands/servers.ts
+++ b/src/commands/servers.ts
@@ -1,7 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 
 import {
-  ServerTokenResponse,
   Server,
   Connector,
   DataSource,

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1,7 +1,3 @@
-export interface ServerTokenResponse {
-  access_token?: string;
-}
-
 interface Provider {
   name: string;
   icon: string;


### PR DESCRIPTION
After this commit[1], type `ServerTokenResponse` became unused, remove it as well.

[1]: https://github.com/infinilabs/coco-app/commit/57ab08fb6da66a7194164cccebd2a9b37ede401f

## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation