### PR TITLE
fix: refreshing Coco server should register it to SearchSource

### DIFF
--- a/src-tauri/src/server/servers.rs
+++ b/src-tauri/src/server/servers.rs
@@ -379,6 +379,7 @@ pub async fn refresh_coco_server_info<R: Runtime>(
 
     // Save and persist
     save_server(&updated_server).await;
+    try_register_server_to_search_source(app_handle.clone(), &updated_server).await;
     persist_servers(&app_handle)
         .await
         .map_err(|e| format!("Failed to persist servers: {}", e))?;


### PR DESCRIPTION
## What does this PR do

If a Coco server is available and enabled by the user, add it to the search source list if it hasn’t been added yet.

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation