### PR TITLE
chore: display backtrace in panic log

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -54,6 +54,7 @@ Information about release notes of Coco Server is provided here.
 - style: splash adapts to the width of mobile phones #768
 - chore: search-chat add language and formatUrl parameters #775
 - chore: not request the interface if not logged in #795
+- chore: display backtrace in panic log #805
 
 ## 0.6.0 (2025-06-29)
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -78,9 +78,13 @@ fn setup_panic_hook() {
             "Unknown location".to_string()
         };
 
+        // Use `force_capture()` instead of `capture()` as we want backtrace
+        // regardless of whether the corresponding env vars are set or not.
+        let backtrace = std::backtrace::Backtrace::force_capture();
+
         let panic_log = format!(
-            "Time: [{}]\nLocation: [{}]\nMessage: [{}]",
-            datetime_str, location, panic_message
+            "Time: [{}]\nLocation: [{}]\nMessage: [{}]\nBacktrace: \n{}",
+            datetime_str, location, panic_message, backtrace
         );
 
         // Write to panic file


### PR DESCRIPTION
Having backtrace in the panic log will help debugging a lot. Under release builds, we strip our binary so the symbols information is unavailable, but this information is still useful in debug builds.

Panic log in release builds:

```
Time: [YYYY-MM-DD-HH-MM-SS]
Location: [/Users/foo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tauri-2.5.1/src/lib.rs:742:7]
Message: [state() called before manage() for tauri_plugin_global_shortcut::GlobalShortcut<tauri_runtime_wry::Wry<tauri::EventLoopMessage>>]
Backtrace:
   0: __mh_execute_header
   1: __mh_execute_header
   2: __mh_execute_header
   3: __mh_execute_header
   4: __mh_execute_header
   5: __mh_execute_header
   6: __mh_execute_header
   7: __mh_execute_header
   8: __mh_execute_header
   9: __mh_execute_header
  10: __mh_execute_header
  11: __mh_execute_header
  12: __mh_execute_header
  13: __mh_execute_header
  14: __mh_execute_header
  15: __mh_execute_header
  16: __mh_execute_header
  17: <unknown>
  18: <unknown>
```

## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation