### PR TITLE
fix: panic caused by "state() called before manage()"

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -35,6 +35,7 @@ Information about release notes of Coco Server is provided here.
 - fix: enter key problem #794
 - fix: fix selection issue after renaming #800
 - fix: fix shortcut issue in windows context menu #804
+- fix: panic caused by "state() called before manage()" #806
 
 ### ✈️ Improvements
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -196,6 +196,11 @@ pub fn run() {
             app.manage(registry); // Store registry in Tauri's app state
             app.manage(server::websocket::WebSocketManager::default());
 
+            // This has to be called before initializing extensions as doing that
+            // requires access to the shortcut store, which will be set by this
+            // function.
+            shortcut::enable_shortcut(app);
+
             block_on(async {
                 init(app.handle()).await;
 
@@ -215,8 +220,6 @@ pub fn run() {
                     }
                 }
             });
-
-            shortcut::enable_shortcut(app);
 
             ensure_autostart_state_consistent(app)?;
 


### PR DESCRIPTION
This commit fixes the following panic:

```
Time: [2025-07-23-17-03-23]
Location: [/Users/steve/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tauri-2.5.1/src/lib.rs:742:7]
Message: [state() called before manage() for tauri_plugin_global_shortcut::GlobalShortcut<tauri_runtime_wry::Wry<tauri::EventLoopMessage>>]
```

The root cause is that, in a Tauri application, before you can access a piece of managed state with the .state() method, you must first register it with Tauri using .manage(). When a user reigsters hotkey for an extension, initializing extensions will invoke the .state() method, at that point, .manage() hasn't been called.

The fix is simple, we simply call .manage() earlies (invoked by our `shortcut::enable_shortcut(app)` function).

## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation