### PR TITLE
fix: panic on Ubuntu (GNOME) when opening apps

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -40,6 +40,7 @@ Information about release notes of Coco Server is provided here.
 - fix: fix ctrl+k not working #815
 - fix: fix update window config sync #818
 - fix: fix enter key on subpages #819
+- fix: panic on Ubuntu (GNOME) when opening apps #821
 
 ### ✈️ Improvements
 

--- a/src-tauri/src/util/mod.rs
+++ b/src-tauri/src/util/mod.rs
@@ -7,9 +7,14 @@ use std::{path::Path, process::Command};
 use tauri::{AppHandle, Runtime};
 use tauri_plugin_shell::ShellExt;
 
+/// We use this env variable to determine the DE on Linux.
+const XDG_CURRENT_DESKTOP: &str = "XDG_CURRENT_DESKTOP";
+
+#[derive(Debug, PartialEq)]
 enum LinuxDesktopEnvironment {
     Gnome,
     Kde,
+    Unsupported { xdg_current_desktop: String },
 }
 
 impl LinuxDesktopEnvironment {
@@ -35,6 +40,14 @@ impl LinuxDesktopEnvironment {
                 .arg(path)
                 .output()
                 .map_err(|e| e.to_string())?,
+            Self::Unsupported {
+                xdg_current_desktop,
+            } => {
+                return Err(format!(
+                    "Cannot open apps as this Linux desktop environment [{}] is not supported",
+                    xdg_current_desktop
+                ));
+            }
         };
 
         if !cmd_output.status.success() {
@@ -49,20 +62,23 @@ impl LinuxDesktopEnvironment {
     }
 }
 
+/// None means that it is likely that we do not have a desktop environment.
 fn get_linux_desktop_environment() -> Option<LinuxDesktopEnvironment> {
-    let de_os_str = std::env::var_os("XDG_CURRENT_DESKTOP")?;
-    let de_str = de_os_str
-        .into_string()
-        .expect("$XDG_CURRENT_DESKTOP should be UTF-8 encoded");
+    let de_os_str = std::env::var_os(XDG_CURRENT_DESKTOP)?;
+    let de_str = de_os_str.into_string().unwrap_or_else(|_os_string| {
+        panic!("${} should be UTF-8 encoded", XDG_CURRENT_DESKTOP);
+    });
 
     let de = match de_str.as_str() {
         "GNOME" => LinuxDesktopEnvironment::Gnome,
+        // Ubuntu uses "ubuntu:GNOME" instead of just "GNOME", they really love
+        // their distro name.
+        "ubuntu:GNOME" => LinuxDesktopEnvironment::Gnome,
         "KDE" => LinuxDesktopEnvironment::Kde,
 
-        unsupported_de => unimplemented!(
-            "This desktop environment [{}] has not been supported yet",
-            unsupported_de
-        ),
+        _ => LinuxDesktopEnvironment::Unsupported {
+            xdg_current_desktop: de_str,
+        },
     };
 
     Some(de)
@@ -77,7 +93,7 @@ pub async fn open<R: Runtime>(app_handle: AppHandle<R>, path: String) -> Result<
         let borrowed_path = Path::new(&path);
         if let Some(file_extension) = borrowed_path.extension() {
             if file_extension == "desktop" {
-                let desktop_environment = get_linux_desktop_environment().expect("The Linux OS is running without a desktop, Coco could never run in such a environment");
+                let desktop_environment = get_linux_desktop_environment().expect("The Linux OS is running without a desktop, Coco could never run in such an environment");
                 return desktop_environment.launch_app_via_desktop_file(path);
             }
         }
@@ -87,4 +103,56 @@ pub async fn open<R: Runtime>(app_handle: AppHandle<R>, path: String) -> Result<
         .shell()
         .open(path, None)
         .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // This test modifies env var XDG_CURRENT_DESKTOP, which is kinda unsafe
+    // but considering this is just test, it is ok to do so.
+    #[test]
+    fn test_get_linux_desktop_environment() {
+        // SAFETY: Rust code won't modify/read XDG_CURRENT_DESKTOP concurrently, we
+        // have no guarantee from the underlying C code.
+        unsafe {
+            // Save the original value if it exists
+            let original_value = std::env::var_os(XDG_CURRENT_DESKTOP);
+
+            // Test when XDG_CURRENT_DESKTOP is not set
+            std::env::remove_var(XDG_CURRENT_DESKTOP);
+            assert!(get_linux_desktop_environment().is_none());
+
+            // Test GNOME
+            std::env::set_var(XDG_CURRENT_DESKTOP, "GNOME");
+            let result = get_linux_desktop_environment();
+            assert_eq!(result.unwrap(), LinuxDesktopEnvironment::Gnome);
+
+            // Test ubuntu:GNOME
+            std::env::set_var(XDG_CURRENT_DESKTOP, "ubuntu:GNOME");
+            let result = get_linux_desktop_environment();
+            assert_eq!(result.unwrap(), LinuxDesktopEnvironment::Gnome);
+
+            // Test KDE
+            std::env::set_var(XDG_CURRENT_DESKTOP, "KDE");
+            let result = get_linux_desktop_environment();
+            assert_eq!(result.unwrap(), LinuxDesktopEnvironment::Kde);
+
+            // Test unsupported desktop environment
+            std::env::set_var(XDG_CURRENT_DESKTOP, "XFCE");
+            let result = get_linux_desktop_environment();
+            assert_eq!(
+                result.unwrap(),
+                LinuxDesktopEnvironment::Unsupported {
+                    xdg_current_desktop: "XFCE".into()
+                }
+            );
+
+            // Restore the original value
+            match original_value {
+                Some(value) => std::env::set_var(XDG_CURRENT_DESKTOP, value),
+                None => std::env::remove_var(XDG_CURRENT_DESKTOP),
+            }
+        }
+    }
 }


### PR DESCRIPTION
On Ubuntu (the GNOME version), Coco would panic when users open an app due to the reason that Coco thinks it is running in an unsupported desktop environment (DE).

We rely on the environment variable XDG_CURRENT_DESKTOP to detect the DE, Ubuntu sets this variable to "ubuntu:GNOME" instead of just "GNOME", which was not handled by the previous implementation.

This commit supports this case. Also, when Coco runs in an unsupported DE, opening apps should not panic the app. After this commit, we would return an error.

## What does this PR do

## Rationale for this change

## Standards checklist

- [ ] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation