### PR TITLE
chore: add toggle_move_to_active_space_attribute

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -852,6 +852,7 @@ dependencies = [
  "cfg-if",
  "chinese-number",
  "chrono",
+ "cocoa 0.24.1",
  "derive_more 2.0.1",
  "dirs 5.0.1",
  "enigo",
@@ -916,16 +917,46 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "cocoa-foundation 0.1.2",
+ "core-foundation 0.9.4",
+ "core-graphics 0.22.3",
+ "foreign-types 0.3.2",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
 dependencies = [
  "bitflags 2.9.0",
  "block",
- "cocoa-foundation",
+ "cocoa-foundation 0.2.0",
  "core-foundation 0.10.0",
- "core-graphics",
+ "core-graphics 0.24.0",
  "foreign-types 0.5.0",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
+dependencies = [
+ "bitflags 1.3.2",
+ "block",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
  "libc",
  "objc",
 ]
@@ -939,7 +970,7 @@ dependencies = [
  "bitflags 2.9.0",
  "block",
  "core-foundation 0.10.0",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "libc",
  "objc",
 ]
@@ -1058,14 +1089,38 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.9.0",
  "core-foundation 0.10.0",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -1472,8 +1527,8 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67fd9ae1736d6ebb2e472740fbee86fb2178b8d56feb98a6751411d4c95b7e72"
 dependencies = [
- "cocoa",
- "core-graphics",
+ "cocoa 0.26.0",
+ "core-graphics 0.24.0",
  "dunce",
  "gdk",
  "gdkx11",
@@ -1562,7 +1617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cf6f550bbbdd5fe66f39d429cb2604bcdacbf00dca0f5bbe2e9306a0009b7c6"
 dependencies = [
  "core-foundation 0.10.0",
- "core-graphics",
+ "core-graphics 0.24.0",
  "foreign-types-shared 0.3.1",
  "libc",
  "log",
@@ -2714,7 +2769,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.59.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5721,7 +5776,7 @@ checksum = "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
- "core-graphics",
+ "core-graphics 0.24.0",
  "foreign-types 0.5.0",
  "js-sys",
  "log",
@@ -5889,7 +5944,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.59.0",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5947,7 +6002,7 @@ checksum = "1e59c1f38e657351a2e822eadf40d6a2ad4627b9c25557bc1180ec1b3295ef82"
 dependencies = [
  "bitflags 2.9.0",
  "core-foundation 0.10.0",
- "core-graphics",
+ "core-graphics 0.24.0",
  "crossbeam-channel",
  "dispatch",
  "dlopen2",
@@ -6145,9 +6200,9 @@ source = "git+https://github.com/ahkohd/tauri-nspanel?branch=v2#d4b9df797959f8fa
 dependencies = [
  "bitflags 2.9.0",
  "block",
- "cocoa",
+ "cocoa 0.26.0",
  "core-foundation 0.10.0",
- "core-graphics",
+ "core-graphics 0.24.0",
  "objc",
  "objc-foundation",
  "objc_id",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -109,6 +109,7 @@ sysinfo = "0.35.2"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2" }
+cocoa = "0.24"
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]
 tauri-plugin-single-instance = { version = "2.0.0", features = ["deep-link"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -180,6 +180,8 @@ pub fn run() {
             server::synthesize::synthesize,
             util::file::get_file_icon,
             util::app_lang::update_app_lang,
+            #[cfg(target_os = "macos")]
+            setup::toggle_move_to_active_space_attribute,
         ])
         .setup(|app| {
             let app_handle = app.handle().clone();

--- a/src/commands/system.ts
+++ b/src/commands/system.ts
@@ -35,3 +35,7 @@ export function show_check(): Promise<void> {
 export function hide_check(): Promise<void> {
   return invoke('hide_check');
 }
+
+export function toggle_move_to_active_space_attribute(): Promise<void> {
+  return invoke('toggle_move_to_active_space_attribute');
+}

--- a/src/components/Assistant/ChatHeader.tsx
+++ b/src/components/Assistant/ChatHeader.tsx
@@ -13,6 +13,7 @@ import { useShortcutsStore } from "@/stores/shortcutsStore";
 import { HISTORY_PANEL_ID } from "@/constants";
 import { AssistantList } from "./AssistantList";
 import { ServerList } from "./ServerList";
+import { toggle_move_to_active_space_attribute } from "@/commands/system";
 
 interface ChatHeaderProps {
   clearChat: () => void;
@@ -45,9 +46,9 @@ export function ChatHeader({
       const newPinned = !isPinned;
       await platformAdapter.setAlwaysOnTop(newPinned);
       setIsPinned(newPinned);
+      toggle_move_to_active_space_attribute();
     } catch (err) {
       console.error("Failed to toggle window pin state:", err);
-      setIsPinned(isPinned);
     }
   };
 

--- a/src/components/Assistant/ChatHeader.tsx
+++ b/src/components/Assistant/ChatHeader.tsx
@@ -7,13 +7,12 @@ import PinIcon from "@/icons/Pin";
 import WindowsFullIcon from "@/icons/WindowsFull";
 import { useAppStore } from "@/stores/appStore";
 import type { Chat } from "@/types/chat";
-import platformAdapter from "@/utils/platformAdapter";
 import VisibleKey from "../Common/VisibleKey";
 import { useShortcutsStore } from "@/stores/shortcutsStore";
 import { HISTORY_PANEL_ID } from "@/constants";
 import { AssistantList } from "./AssistantList";
 import { ServerList } from "./ServerList";
-import { toggle_move_to_active_space_attribute } from "@/commands/system";
+import { useTogglePin } from "@/hooks/useTogglePin";
 
 interface ChatHeaderProps {
   clearChat: () => void;
@@ -36,21 +35,11 @@ export function ChatHeader({
   showChatHistory = true,
   assistantIDs,
 }: ChatHeaderProps) {
-  const { isPinned, setIsPinned, isTauri } = useAppStore();
+  const { isTauri } = useAppStore();
+  const { isPinned, togglePin } = useTogglePin();
 
   const { historicalRecords, newSession, fixedWindow, external } =
     useShortcutsStore();
-
-  const togglePin = async () => {
-    try {
-      const newPinned = !isPinned;
-      await platformAdapter.setAlwaysOnTop(newPinned);
-      setIsPinned(newPinned);
-      toggle_move_to_active_space_attribute();
-    } catch (err) {
-      console.error("Failed to toggle window pin state:", err);
-    }
-  };
 
   return (
     <header

--- a/src/components/Common/UI/Footer.tsx
+++ b/src/components/Common/UI/Footer.tsx
@@ -19,6 +19,7 @@ import source_default_dark_img from "@/assets/images/source_default_dark.png";
 import { useThemeStore } from "@/stores/themeStore";
 import platformAdapter from "@/utils/platformAdapter";
 import FontIcon from "../Icons/FontIcon";
+import { toggle_move_to_active_space_attribute } from "@/commands/system";
 
 interface FooterProps {
   setIsPinnedWeb?: (value: boolean) => void;
@@ -53,9 +54,9 @@ export default function Footer({ setIsPinnedWeb }: FooterProps) {
       const newPinned = !isPinned;
       await setWindowAlwaysOnTop(newPinned);
       setIsPinned(newPinned);
+      toggle_move_to_active_space_attribute();
     } catch (err) {
       console.error("Failed to toggle window pin state:", err);
-      setIsPinned(isPinned);
     }
   };
 

--- a/src/components/Common/UI/Footer.tsx
+++ b/src/components/Common/UI/Footer.tsx
@@ -19,7 +19,7 @@ import source_default_dark_img from "@/assets/images/source_default_dark.png";
 import { useThemeStore } from "@/stores/themeStore";
 import platformAdapter from "@/utils/platformAdapter";
 import FontIcon from "../Icons/FontIcon";
-import { toggle_move_to_active_space_attribute } from "@/commands/system";
+import { useTogglePin } from "@/hooks/useTogglePin";
 
 interface FooterProps {
   setIsPinnedWeb?: (value: boolean) => void;
@@ -38,27 +38,15 @@ export default function Footer({ setIsPinnedWeb }: FooterProps) {
 
   const isDark = useThemeStore((state) => state.isDark);
 
-  const { isTauri, isPinned, setIsPinned } = useAppStore();
+  const { isTauri } = useAppStore();
+
+  const { isPinned, togglePin } = useTogglePin({
+    onPinChange: setIsPinnedWeb,
+  });
 
   const { setVisible, updateInfo } = useUpdateStore();
 
   const { fixedWindow, modifierKey } = useShortcutsStore();
-
-  const setWindowAlwaysOnTop = useCallback(async (isPinned: boolean) => {
-    setIsPinnedWeb?.(isPinned);
-    return platformAdapter.setAlwaysOnTop(isPinned);
-  }, []);
-
-  const togglePin = async () => {
-    try {
-      const newPinned = !isPinned;
-      await setWindowAlwaysOnTop(newPinned);
-      setIsPinned(newPinned);
-      toggle_move_to_active_space_attribute();
-    } catch (err) {
-      console.error("Failed to toggle window pin state:", err);
-    }
-  };
 
   const openSetting = useCallback(() => {
     return platformAdapter.emitEvent("open_settings", "");

--- a/src/hooks/useTogglePin.ts
+++ b/src/hooks/useTogglePin.ts
@@ -1,0 +1,34 @@
+import { useCallback } from "react";
+
+import { useAppStore } from "@/stores/appStore";
+import platformAdapter from "@/utils/platformAdapter";
+import { toggle_move_to_active_space_attribute } from "@/commands/system";
+
+interface UseTogglePinOptions {
+  onPinChange?: (isPinned: boolean) => void;
+}
+
+export const useTogglePin = (options?: UseTogglePinOptions) => {
+  const { isPinned, setIsPinned } = useAppStore();
+
+  const togglePin = useCallback(async () => {
+    try {
+      const newPinned = !isPinned;
+
+      if (options?.onPinChange) {
+        options.onPinChange(newPinned);
+      }
+
+      await platformAdapter.setAlwaysOnTop(newPinned);
+      setIsPinned(newPinned);
+      toggle_move_to_active_space_attribute();
+    } catch (err) {
+      console.error("Failed to toggle window pin state:", err);
+    }
+  }, [isPinned, setIsPinned, options?.onPinChange]);
+
+  return {
+    isPinned,
+    togglePin,
+  };
+};

--- a/src/hooks/useTogglePin.ts
+++ b/src/hooks/useTogglePin.ts
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { useAppStore } from "@/stores/appStore";
 import platformAdapter from "@/utils/platformAdapter";
 import { toggle_move_to_active_space_attribute } from "@/commands/system";
+import { isMac } from "@/utils/platform";
 
 interface UseTogglePinOptions {
   onPinChange?: (isPinned: boolean) => void;
@@ -21,7 +22,7 @@ export const useTogglePin = (options?: UseTogglePinOptions) => {
 
       await platformAdapter.setAlwaysOnTop(newPinned);
       setIsPinned(newPinned);
-      toggle_move_to_active_space_attribute();
+      isMac && toggle_move_to_active_space_attribute();
     } catch (err) {
       console.error("Failed to toggle window pin state:", err);
     }


### PR DESCRIPTION
## What does this PR do

This commit changes the default NS window attribute from `NSWindowCollectionBehaviorCanJoinAllSpaces` to `NSWindowCollectionBehaviorMoveToActiveSpace`. `NSWindowCollectionBehaviorCanJoinAllSpaces` has an issue on my macOS that the main window cannot be opened after running Coco for a while.

Pinning the main window would bring `NSWindowCollectionBehaviorCanJoinAllSpaces` back to make it really stay pinned across all the spaces. A tauri command `toggle_move_to_active_space_attribute()` is added to make this happen.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation