### PR TITLE
chore: ignore tauri::AppHandle's generic argument R

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -25,6 +25,7 @@ Information about release notes of Coco App is provided here.
 - refactor: split query_coco_fusion() #836
 - chore: web component loading font icon #838
 - chore: delete unused code files and dependencies #841
+- chore: ignore tauri::AppHandle's generic argument R #845
 
 ## 0.7.1 (2025-07-27)
 

--- a/src-tauri/src/assistant/mod.rs
+++ b/src-tauri/src/assistant/mod.rs
@@ -9,12 +9,12 @@ use futures_util::TryStreamExt;
 use http::Method;
 use serde_json::Value;
 use std::collections::HashMap;
-use tauri::{AppHandle, Emitter, Manager, Runtime};
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::AsyncBufReadExt;
 
 #[tauri::command]
-pub async fn chat_history<R: Runtime>(
-    _app_handle: AppHandle<R>,
+pub async fn chat_history(
+    _app_handle: AppHandle,
     server_id: String,
     from: u32,
     size: u32,
@@ -43,8 +43,8 @@ pub async fn chat_history<R: Runtime>(
 }
 
 #[tauri::command]
-pub async fn session_chat_history<R: Runtime>(
-    _app_handle: AppHandle<R>,
+pub async fn session_chat_history(
+    _app_handle: AppHandle,
     server_id: String,
     session_id: String,
     from: u32,
@@ -66,8 +66,8 @@ pub async fn session_chat_history<R: Runtime>(
 }
 
 #[tauri::command]
-pub async fn open_session_chat<R: Runtime>(
-    _app_handle: AppHandle<R>,
+pub async fn open_session_chat(
+    _app_handle: AppHandle,
     server_id: String,
     session_id: String,
 ) -> Result<String, String> {
@@ -81,8 +81,8 @@ pub async fn open_session_chat<R: Runtime>(
 }
 
 #[tauri::command]
-pub async fn close_session_chat<R: Runtime>(
-    _app_handle: AppHandle<R>,
+pub async fn close_session_chat(
+    _app_handle: AppHandle,
     server_id: String,
     session_id: String,
 ) -> Result<String, String> {
@@ -95,8 +95,8 @@ pub async fn close_session_chat<R: Runtime>(
     common::http::get_response_body_text(response).await
 }
 #[tauri::command]
-pub async fn cancel_session_chat<R: Runtime>(
-    _app_handle: AppHandle<R>,
+pub async fn cancel_session_chat(
+    _app_handle: AppHandle,
     server_id: String,
     session_id: String,
     query_params: Option<HashMap<String, Value>>,
@@ -112,8 +112,8 @@ pub async fn cancel_session_chat<R: Runtime>(
 }
 
 #[tauri::command]
-pub async fn chat_create<R: Runtime>(
-    app_handle: AppHandle<R>,
+pub async fn chat_create(
+    app_handle: AppHandle,
     server_id: String,
     message: String,
     query_params: Option<HashMap<String, Value>>,
@@ -175,8 +175,8 @@ pub async fn chat_create<R: Runtime>(
 }
 
 #[tauri::command]
-pub async fn chat_chat<R: Runtime>(
-    app_handle: AppHandle<R>,
+pub async fn chat_chat(
+    app_handle: AppHandle,
     server_id: String,
     session_id: String,
     message: String,
@@ -286,8 +286,8 @@ pub async fn update_session_chat(
 }
 
 #[tauri::command]
-pub async fn assistant_search<R: Runtime>(
-    _app_handle: AppHandle<R>,
+pub async fn assistant_search(
+    _app_handle: AppHandle,
     server_id: String,
     query_params: Option<Vec<String>>,
 ) -> Result<Value, String> {
@@ -302,8 +302,8 @@ pub async fn assistant_search<R: Runtime>(
 }
 
 #[tauri::command]
-pub async fn assistant_get<R: Runtime>(
-    _app_handle: AppHandle<R>,
+pub async fn assistant_get(
+    _app_handle: AppHandle,
     server_id: String,
     assistant_id: String,
 ) -> Result<Value, String> {
@@ -326,8 +326,8 @@ pub async fn assistant_get<R: Runtime>(
 ///
 /// Returns as soon as the assistant is found on any Coco server.
 #[tauri::command]
-pub async fn assistant_get_multi<R: Runtime>(
-    app_handle: AppHandle<R>,
+pub async fn assistant_get_multi(
+    app_handle: AppHandle,
     assistant_id: String,
 ) -> Result<Value, String> {
     let search_sources = app_handle.state::<SearchSourceRegistry>();
@@ -420,8 +420,8 @@ pub fn remove_icon_fields(json: &str) -> String {
 }
 
 #[tauri::command]
-pub async fn ask_ai<R: Runtime>(
-    app_handle: AppHandle<R>,
+pub async fn ask_ai(
+    app_handle: AppHandle,
     message: String,
     server_id: String,
     assistant_id: String,

--- a/src-tauri/src/autostart.rs
+++ b/src-tauri/src/autostart.rs
@@ -1,6 +1,6 @@
 use std::{fs::create_dir, io::Read};
 
-use tauri::{Manager, Runtime};
+use tauri::Manager;
 use tauri_plugin_autostart::ManagerExt;
 
 /// If the state reported from the OS and the state stored by us differ, our state is
@@ -42,7 +42,7 @@ pub fn ensure_autostart_state_consistent(app: &mut tauri::App) -> Result<(), Str
     Ok(())
 }
 
-fn current_autostart<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<bool, String> {
+fn current_autostart(app: &tauri::AppHandle) -> Result<bool, String> {
     use std::fs::File;
 
     let path = app.path().app_config_dir().unwrap();
@@ -65,10 +65,7 @@ fn current_autostart<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<bool, Stri
 }
 
 #[tauri::command]
-pub async fn change_autostart<R: Runtime>(
-    app: tauri::AppHandle<R>,
-    open: bool,
-) -> Result<(), String> {
+pub async fn change_autostart(app: tauri::AppHandle, open: bool) -> Result<(), String> {
     use std::fs::File;
     use std::io::Write;
 

--- a/src-tauri/src/extension/built_in/application/without_feature.rs
+++ b/src-tauri/src/extension/built_in/application/without_feature.rs
@@ -5,16 +5,14 @@ use crate::common::search::{QueryResponse, QuerySource, SearchQuery};
 use crate::common::traits::SearchSource;
 use crate::extension::LOCAL_QUERY_SOURCE_TYPE;
 use async_trait::async_trait;
-use tauri::{AppHandle, Runtime};
+use tauri::AppHandle;
 
 pub(crate) const QUERYSOURCE_ID_DATASOURCE_ID_DATASOURCE_NAME: &str = "Applications";
 
 pub struct ApplicationSearchSource;
 
 impl ApplicationSearchSource {
-    pub async fn prepare_index_and_store<R: Runtime>(
-        _app_handle: AppHandle<R>,
-    ) -> Result<(), String> {
+    pub async fn prepare_index_and_store(_app_handle: AppHandle) -> Result<(), String> {
         Ok(())
     }
 }
@@ -45,37 +43,28 @@ impl SearchSource for ApplicationSearchSource {
     }
 }
 
-pub fn set_app_alias<R: Runtime>(_tauri_app_handle: &AppHandle<R>, _app_path: &str, _alias: &str) {
+pub fn set_app_alias(_tauri_app_handle: &AppHandle, _app_path: &str, _alias: &str) {
     unreachable!("app list should be empty, there is no way this can be invoked")
 }
 
-pub fn register_app_hotkey<R: Runtime>(
-    _tauri_app_handle: &AppHandle<R>,
+pub fn register_app_hotkey(
+    _tauri_app_handle: &AppHandle,
     _app_path: &str,
     _hotkey: &str,
 ) -> Result<(), String> {
     unreachable!("app list should be empty, there is no way this can be invoked")
 }
 
-pub fn unregister_app_hotkey<R: Runtime>(
-    _tauri_app_handle: &AppHandle<R>,
-    _app_path: &str,
-) -> Result<(), String> {
+pub fn unregister_app_hotkey(_tauri_app_handle: &AppHandle, _app_path: &str) -> Result<(), String> {
     unreachable!("app list should be empty, there is no way this can be invoked")
 }
 
-pub fn disable_app_search<R: Runtime>(
-    _tauri_app_handle: &AppHandle<R>,
-    _app_path: &str,
-) -> Result<(), String> {
+pub fn disable_app_search(_tauri_app_handle: &AppHandle, _app_path: &str) -> Result<(), String> {
     // no-op
     Ok(())
 }
 
-pub fn enable_app_search<R: Runtime>(
-    _tauri_app_handle: &AppHandle<R>,
-    _app_path: &str,
-) -> Result<(), String> {
+pub fn enable_app_search(_tauri_app_handle: &AppHandle, _app_path: &str) -> Result<(), String> {
     // no-op
     Ok(())
 }
@@ -85,8 +74,8 @@ pub fn is_app_search_enabled(_app_path: &str) -> bool {
 }
 
 #[tauri::command]
-pub async fn add_app_search_path<R: Runtime>(
-    _tauri_app_handle: AppHandle<R>,
+pub async fn add_app_search_path(
+    _tauri_app_handle: AppHandle,
     _search_path: String,
 ) -> Result<(), String> {
     // no-op
@@ -94,8 +83,8 @@ pub async fn add_app_search_path<R: Runtime>(
 }
 
 #[tauri::command]
-pub async fn remove_app_search_path<R: Runtime>(
-    _tauri_app_handle: AppHandle<R>,
+pub async fn remove_app_search_path(
+    _tauri_app_handle: AppHandle,
     _search_path: String,
 ) -> Result<(), String> {
     // no-op
@@ -103,43 +92,37 @@ pub async fn remove_app_search_path<R: Runtime>(
 }
 
 #[tauri::command]
-pub async fn get_app_search_path<R: Runtime>(_tauri_app_handle: AppHandle<R>) -> Vec<String> {
+pub async fn get_app_search_path(_tauri_app_handle: AppHandle) -> Vec<String> {
     // Return an empty list
     Vec::new()
 }
 
 #[tauri::command]
-pub async fn get_app_list<R: Runtime>(
-    _tauri_app_handle: AppHandle<R>,
-) -> Result<Vec<Extension>, String> {
+pub async fn get_app_list(_tauri_app_handle: AppHandle) -> Result<Vec<Extension>, String> {
     // Return an empty list
     Ok(Vec::new())
 }
 
 #[tauri::command]
-pub async fn get_app_metadata<R: Runtime>(
-    _tauri_app_handle: AppHandle<R>,
+pub async fn get_app_metadata(
+    _tauri_app_handle: AppHandle,
     _app_path: String,
 ) -> Result<AppMetadata, String> {
     unreachable!("app list should be empty, there is no way this can be invoked")
 }
 
-pub(crate) fn set_apps_hotkey<R: Runtime>(_tauri_app_handle: &AppHandle<R>) -> Result<(), String> {
+pub(crate) fn set_apps_hotkey(_tauri_app_handle: &AppHandle) -> Result<(), String> {
     // no-op
     Ok(())
 }
 
-pub(crate) fn unset_apps_hotkey<R: Runtime>(
-    _tauri_app_handle: &AppHandle<R>,
-) -> Result<(), String> {
+pub(crate) fn unset_apps_hotkey(_tauri_app_handle: &AppHandle) -> Result<(), String> {
     // no-op
     Ok(())
 }
 
 #[tauri::command]
-pub async fn reindex_applications<R: Runtime>(
-    _tauri_app_handle: AppHandle<R>,
-) -> Result<(), String> {
+pub async fn reindex_applications(_tauri_app_handle: AppHandle) -> Result<(), String> {
     // no-op
     Ok(())
 }

--- a/src-tauri/src/extension/built_in/file_search/config.rs
+++ b/src-tauri/src/extension/built_in/file_search/config.rs
@@ -5,7 +5,6 @@ use serde::Serialize;
 use serde_json::Value;
 use std::sync::LazyLock;
 use tauri::AppHandle;
-use tauri::Runtime;
 use tauri_plugin_store::StoreExt;
 
 // Tauri store keys for file system configuration
@@ -54,7 +53,7 @@ impl Default for FileSearchConfig {
 }
 
 impl FileSearchConfig {
-    pub(crate) fn get<R: Runtime>(tauri_app_handle: &AppHandle<R>) -> Self {
+    pub(crate) fn get(tauri_app_handle: &AppHandle) -> Self {
         let store = tauri_app_handle
             .store(TAURI_STORE_FILE_SYSTEM_CONFIG)
             .unwrap_or_else(|e| {
@@ -185,15 +184,13 @@ impl FileSearchConfig {
 
 // Tauri commands for managing file system configuration
 #[tauri::command]
-pub async fn get_file_system_config<R: Runtime>(
-    tauri_app_handle: AppHandle<R>,
-) -> FileSearchConfig {
+pub async fn get_file_system_config(tauri_app_handle: AppHandle) -> FileSearchConfig {
     FileSearchConfig::get(&tauri_app_handle)
 }
 
 #[tauri::command]
-pub async fn set_file_system_config<R: Runtime>(
-    tauri_app_handle: AppHandle<R>,
+pub async fn set_file_system_config(
+    tauri_app_handle: AppHandle,
     config: FileSearchConfig,
 ) -> Result<(), String> {
     let store = tauri_app_handle

--- a/src-tauri/src/extension/built_in/mod.rs
+++ b/src-tauri/src/extension/built_in/mod.rs
@@ -16,11 +16,9 @@ use crate::extension::{
 };
 use anyhow::Context;
 use std::path::{Path, PathBuf};
-use tauri::{AppHandle, Manager, Runtime};
+use tauri::{AppHandle, Manager};
 
-pub(crate) fn get_built_in_extension_directory<R: Runtime>(
-    tauri_app_handle: &AppHandle<R>,
-) -> PathBuf {
+pub(crate) fn get_built_in_extension_directory(tauri_app_handle: &AppHandle) -> PathBuf {
     let mut resource_dir = tauri_app_handle.path().app_data_dir().expect(
         "User home directory not found, which should be impossible on desktop environments",
     );
@@ -136,8 +134,8 @@ async fn load_built_in_extension(
 /// We only read alias/hotkey/enabled from the JSON file, we have ensured that if
 /// alias/hotkey is not supported, then it will be `None`. Besides that, no further
 /// validation is needed because nothing could go wrong.
-pub(crate) async fn list_built_in_extensions<R: Runtime>(
-    tauri_app_handle: &AppHandle<R>,
+pub(crate) async fn list_built_in_extensions(
+    tauri_app_handle: &AppHandle,
 ) -> Result<Vec<Extension>, String> {
     let dir = get_built_in_extension_directory(tauri_app_handle);
 
@@ -191,8 +189,8 @@ pub(crate) async fn list_built_in_extensions<R: Runtime>(
     Ok(built_in_extensions)
 }
 
-pub(super) async fn init_built_in_extension<R: Runtime>(
-    tauri_app_handle: &AppHandle<R>,
+pub(super) async fn init_built_in_extension(
+    tauri_app_handle: &AppHandle,
     extension: &Extension,
     search_source_registry: &SearchSourceRegistry,
 ) -> Result<(), String> {
@@ -233,8 +231,8 @@ pub(crate) fn is_extension_built_in(bundle_id: &ExtensionBundleIdBorrowed<'_>) -
     bundle_id.developer.is_none()
 }
 
-pub(crate) async fn enable_built_in_extension<R: Runtime>(
-    tauri_app_handle: &AppHandle<R>,
+pub(crate) async fn enable_built_in_extension(
+    tauri_app_handle: &AppHandle,
     bundle_id: &ExtensionBundleIdBorrowed<'_>,
 ) -> Result<(), String> {
     let search_source_registry_tauri_state = tauri_app_handle.state::<SearchSourceRegistry>();
@@ -321,8 +319,8 @@ pub(crate) async fn enable_built_in_extension<R: Runtime>(
     Ok(())
 }
 
-pub(crate) async fn disable_built_in_extension<R: Runtime>(
-    tauri_app_handle: &AppHandle<R>,
+pub(crate) async fn disable_built_in_extension(
+    tauri_app_handle: &AppHandle,
     bundle_id: &ExtensionBundleIdBorrowed<'_>,
 ) -> Result<(), String> {
     let search_source_registry_tauri_state = tauri_app_handle.state::<SearchSourceRegistry>();
@@ -408,8 +406,8 @@ pub(crate) async fn disable_built_in_extension<R: Runtime>(
     Ok(())
 }
 
-pub(crate) fn set_built_in_extension_alias<R: Runtime>(
-    tauri_app_handle: &AppHandle<R>,
+pub(crate) fn set_built_in_extension_alias(
+    tauri_app_handle: &AppHandle,
     bundle_id: &ExtensionBundleIdBorrowed<'_>,
     alias: &str,
 ) {
@@ -420,8 +418,8 @@ pub(crate) fn set_built_in_extension_alias<R: Runtime>(
     }
 }
 
-pub(crate) fn register_built_in_extension_hotkey<R: Runtime>(
-    tauri_app_handle: &AppHandle<R>,
+pub(crate) fn register_built_in_extension_hotkey(
+    tauri_app_handle: &AppHandle,
     bundle_id: &ExtensionBundleIdBorrowed<'_>,
     hotkey: &str,
 ) -> Result<(), String> {
@@ -433,8 +431,8 @@ pub(crate) fn register_built_in_extension_hotkey<R: Runtime>(
     Ok(())
 }
 
-pub(crate) fn unregister_built_in_extension_hotkey<R: Runtime>(
-    tauri_app_handle: &AppHandle<R>,
+pub(crate) fn unregister_built_in_extension_hotkey(
+    tauri_app_handle: &AppHandle,
     bundle_id: &ExtensionBundleIdBorrowed<'_>,
 ) -> Result<(), String> {
     if bundle_id.extension_id == application::QUERYSOURCE_ID_DATASOURCE_ID_DATASOURCE_NAME {
@@ -481,8 +479,8 @@ fn load_extension_from_json_file(
     Ok(extension)
 }
 
-pub(crate) async fn is_built_in_extension_enabled<R: Runtime>(
-    tauri_app_handle: &AppHandle<R>,
+pub(crate) async fn is_built_in_extension_enabled(
+    tauri_app_handle: &AppHandle,
     bundle_id: &ExtensionBundleIdBorrowed<'_>,
 ) -> Result<bool, String> {
     let search_source_registry_tauri_state = tauri_app_handle.state::<SearchSourceRegistry>();

--- a/src-tauri/src/extension/mod.rs
+++ b/src-tauri/src/extension/mod.rs
@@ -14,7 +14,7 @@ use serde_json::Value as Json;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
-use tauri::{AppHandle, Manager, Runtime};
+use tauri::{AppHandle, Manager};
 use third_party::THIRD_PARTY_EXTENSIONS_SEARCH_SOURCE;
 
 pub const LOCAL_QUERY_SOURCE_TYPE: &str = "local";
@@ -592,8 +592,8 @@ fn filter_out_extensions(
 /// * boolean: indicates if we found any invalid extensions
 /// * Vec<Extension>: loaded extensions
 #[tauri::command]
-pub(crate) async fn list_extensions<R: Runtime>(
-    tauri_app_handle: AppHandle<R>,
+pub(crate) async fn list_extensions(
+    tauri_app_handle: AppHandle,
     query: Option<String>,
     extension_type: Option<ExtensionType>,
     list_enabled: bool,

--- a/src-tauri/src/extension/third_party/install/local_extension.rs
+++ b/src-tauri/src/extension/third_party/install/local_extension.rs
@@ -7,7 +7,7 @@ use crate::extension::{Extension, canonicalize_relative_icon_path};
 use serde_json::Value as Json;
 use std::path::Path;
 use std::path::PathBuf;
-use tauri::{AppHandle, Runtime};
+use tauri::AppHandle;
 use tokio::fs;
 
 /// All the extensions installed from local file will belong to a special developer
@@ -26,8 +26,8 @@ const DEVELOPER_ID_LOCAL: &str = "__local__";
 /// └── plugin.json
 /// ```
 #[tauri::command]
-pub(crate) async fn install_local_extension<R: Runtime>(
-    tauri_app_handle: AppHandle<R>,
+pub(crate) async fn install_local_extension(
+    tauri_app_handle: AppHandle,
     path: PathBuf,
 ) -> Result<(), String> {
     let extension_dir_name = path

--- a/src-tauri/src/extension/third_party/mod.rs
+++ b/src-tauri/src/extension/third_party/mod.rs
@@ -26,7 +26,6 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use tauri::AppHandle;
 use tauri::Manager;
-use tauri::Runtime;
 use tauri::async_runtime;
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
 use tauri_plugin_global_shortcut::ShortcutState;
@@ -34,9 +33,7 @@ use tokio::fs::read_dir;
 use tokio::sync::RwLock;
 use tokio::sync::RwLockWriteGuard;
 
-pub(crate) fn get_third_party_extension_directory<R: Runtime>(
-    tauri_app_handle: &AppHandle<R>,
-) -> PathBuf {
+pub(crate) fn get_third_party_extension_directory(tauri_app_handle: &AppHandle) -> PathBuf {
     let mut app_data_dir = tauri_app_handle.path().app_data_dir().expect(
         "User home directory not found, which should be impossible on desktop environments",
     );

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,7 +19,7 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 use tauri::async_runtime::block_on;
 use tauri::plugin::TauriPlugin;
-use tauri::{AppHandle, Emitter, Manager, PhysicalPosition, Runtime, WebviewWindow, WindowEvent};
+use tauri::{AppHandle, Emitter, Manager, PhysicalPosition, WebviewWindow, WindowEvent};
 use tauri_plugin_autostart::MacosLauncher;
 
 /// Tauri store name
@@ -290,7 +290,7 @@ pub fn run() {
     });
 }
 
-pub async fn init<R: Runtime>(app_handle: &AppHandle<R>) {
+pub async fn init(app_handle: &AppHandle) {
     // Await the async functions to load the servers and tokens
     if let Err(err) = load_or_insert_default_server(app_handle).await {
         log::error!("Failed to load servers: {}", err);
@@ -314,7 +314,7 @@ pub async fn init<R: Runtime>(app_handle: &AppHandle<R>) {
 }
 
 #[tauri::command]
-async fn show_coco<R: Runtime>(app_handle: AppHandle<R>) {
+async fn show_coco(app_handle: AppHandle) {
     if let Some(window) = app_handle.get_webview_window(MAIN_WINDOW_LABEL) {
         move_window_to_active_monitor(&window);
 
@@ -327,7 +327,7 @@ async fn show_coco<R: Runtime>(app_handle: AppHandle<R>) {
 }
 
 #[tauri::command]
-async fn hide_coco<R: Runtime>(app: AppHandle<R>) {
+async fn hide_coco(app: AppHandle) {
     if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
         if let Err(err) = window.hide() {
             log::error!("Failed to hide the window: {}", err);
@@ -339,7 +339,7 @@ async fn hide_coco<R: Runtime>(app: AppHandle<R>) {
     }
 }
 
-fn move_window_to_active_monitor<R: Runtime>(window: &WebviewWindow<R>) {
+fn move_window_to_active_monitor(window: &WebviewWindow) {
     //dbg!("Moving window to active monitor");
     // Try to get the available monitors, handle failure gracefully
     let available_monitors = match window.available_monitors() {

--- a/src-tauri/src/server/auth.rs
+++ b/src-tauri/src/server/auth.rs
@@ -4,7 +4,7 @@ use crate::server::servers::{
     get_server_by_id, persist_servers, persist_servers_token, save_access_token, save_server,
     try_register_server_to_search_source,
 };
-use tauri::{AppHandle, Runtime};
+use tauri::AppHandle;
 
 #[allow(dead_code)]
 fn request_access_token_url(request_id: &str) -> String {
@@ -13,8 +13,8 @@ fn request_access_token_url(request_id: &str) -> String {
 }
 
 #[tauri::command]
-pub async fn handle_sso_callback<R: Runtime>(
-    app_handle: AppHandle<R>,
+pub async fn handle_sso_callback(
+    app_handle: AppHandle,
     server_id: String,
     request_id: String,
     code: String,

--- a/src-tauri/src/server/connector.rs
+++ b/src-tauri/src/server/connector.rs
@@ -6,7 +6,7 @@ use http::StatusCode;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use tauri::{AppHandle, Runtime};
+use tauri::AppHandle;
 
 lazy_static! {
     static ref CONNECTOR_CACHE: Arc<RwLock<HashMap<String, HashMap<String, Connector>>>> =
@@ -29,7 +29,7 @@ pub fn get_connector_by_id(server_id: &str, connector_id: &str) -> Option<Connec
     Some(connector.clone())
 }
 
-pub async fn refresh_all_connectors<R: Runtime>(app_handle: &AppHandle<R>) -> Result<(), String> {
+pub async fn refresh_all_connectors(app_handle: &AppHandle) -> Result<(), String> {
     let servers = get_all_servers().await;
 
     // Collect all the tasks for fetching and refreshing connectors
@@ -122,8 +122,8 @@ pub async fn fetch_connectors_by_server(id: &str) -> Result<Vec<Connector>, Stri
 }
 
 #[tauri::command]
-pub async fn get_connectors_by_server<R: Runtime>(
-    _app_handle: AppHandle<R>,
+pub async fn get_connectors_by_server(
+    _app_handle: AppHandle,
     id: String,
 ) -> Result<Vec<Connector>, String> {
     let connectors = fetch_connectors_by_server(&id).await?;

--- a/src-tauri/src/server/datasource.rs
+++ b/src-tauri/src/server/datasource.rs
@@ -7,7 +7,7 @@ use http::StatusCode;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use tauri::{AppHandle, Runtime};
+use tauri::AppHandle;
 
 lazy_static! {
     static ref DATASOURCE_CACHE: Arc<RwLock<HashMap<String, HashMap<String, DataSource>>>> =
@@ -31,7 +31,7 @@ pub fn get_datasources_from_cache(server_id: &str) -> Option<HashMap<String, Dat
     Some(server_cache.clone())
 }
 
-pub async fn refresh_all_datasources<R: Runtime>(_app_handle: &AppHandle<R>) -> Result<(), String> {
+pub async fn refresh_all_datasources(_app_handle: &AppHandle) -> Result<(), String> {
     // dbg!("Attempting to refresh all datasources");
 
     let servers = get_all_servers().await;

--- a/src-tauri/src/server/profile.rs
+++ b/src-tauri/src/server/profile.rs
@@ -1,11 +1,11 @@
 use crate::common::http::get_response_body_text;
 use crate::common::profile::UserProfile;
 use crate::server::http_client::HttpClient;
-use tauri::{AppHandle, Runtime};
+use tauri::AppHandle;
 
 #[tauri::command]
-pub async fn get_user_profiles<R: Runtime>(
-    _app_handle: AppHandle<R>,
+pub async fn get_user_profiles(
+    _app_handle: AppHandle,
     server_id: String,
 ) -> Result<UserProfile, String> {
     // Use the generic GET method from HttpClient

--- a/src-tauri/src/server/synthesize.rs
+++ b/src-tauri/src/server/synthesize.rs
@@ -2,11 +2,11 @@ use crate::server::http_client::HttpClient;
 use futures_util::StreamExt;
 use http::Method;
 use serde_json::json;
-use tauri::{AppHandle, Emitter, Runtime, command};
+use tauri::{AppHandle, Emitter, command};
 
 #[command]
-pub async fn synthesize<R: Runtime>(
-    app_handle: AppHandle<R>,
+pub async fn synthesize(
+    app_handle: AppHandle,
     client_id: String,
     server_id: String,
     voice: String,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,12 +1,12 @@
 use crate::COCO_TAURI_STORE;
 use serde_json::Value as Json;
-use tauri::{AppHandle, Runtime};
+use tauri::AppHandle;
 use tauri_plugin_store::StoreExt;
 
 const SETTINGS_ALLOW_SELF_SIGNATURE: &str = "settings_allow_self_signature";
 
 #[tauri::command]
-pub async fn set_allow_self_signature<R: Runtime>(tauri_app_handle: AppHandle<R>, value: bool) {
+pub async fn set_allow_self_signature(tauri_app_handle: AppHandle, value: bool) {
     use crate::server::http_client;
 
     let store = tauri_app_handle
@@ -40,7 +40,7 @@ pub async fn set_allow_self_signature<R: Runtime>(tauri_app_handle: AppHandle<R>
 }
 
 /// Synchronous version of `async get_allow_self_signature()`.
-pub fn _get_allow_self_signature<R: Runtime>(tauri_app_handle: AppHandle<R>) -> bool {
+pub fn _get_allow_self_signature(tauri_app_handle: AppHandle) -> bool {
     let store = tauri_app_handle
         .store(COCO_TAURI_STORE)
         .unwrap_or_else(|e| {
@@ -67,6 +67,6 @@ pub fn _get_allow_self_signature<R: Runtime>(tauri_app_handle: AppHandle<R>) -> 
 }
 
 #[tauri::command]
-pub async fn get_allow_self_signature<R: Runtime>(tauri_app_handle: AppHandle<R>) -> bool {
+pub async fn get_allow_self_signature(tauri_app_handle: AppHandle) -> bool {
     _get_allow_self_signature(tauri_app_handle)
 }

--- a/src-tauri/src/shortcut.rs
+++ b/src-tauri/src/shortcut.rs
@@ -1,5 +1,5 @@
 use crate::{COCO_TAURI_STORE, hide_coco, show_coco};
-use tauri::{App, AppHandle, Manager, Runtime, async_runtime};
+use tauri::{App, AppHandle, Manager, async_runtime};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 use tauri_plugin_store::{JsonValue, StoreExt};
 
@@ -50,14 +50,14 @@ pub fn enable_shortcut(app: &App) {
 /// Get the stored shortcut as a string, same as [`_get_shortcut()`], except that
 /// this is a `tauri::command` interface.
 #[tauri::command]
-pub async fn get_current_shortcut<R: Runtime>(app: AppHandle<R>) -> Result<String, String> {
+pub async fn get_current_shortcut(app: AppHandle) -> Result<String, String> {
     let shortcut = _get_shortcut(&app);
     Ok(shortcut)
 }
 
 /// Get the current shortcut and unregister it on the tauri side.
 #[tauri::command]
-pub async fn unregister_shortcut<R: Runtime>(app: AppHandle<R>) {
+pub async fn unregister_shortcut(app: AppHandle) {
     let shortcut_str = _get_shortcut(&app);
     let shortcut = shortcut_str
         .parse::<Shortcut>()
@@ -70,9 +70,9 @@ pub async fn unregister_shortcut<R: Runtime>(app: AppHandle<R>) {
 
 /// Change the global shortcut to `key`.
 #[tauri::command]
-pub async fn change_shortcut<R: Runtime>(
-    app: AppHandle<R>,
-    _window: tauri::Window<R>,
+pub async fn change_shortcut(
+    app: AppHandle,
+    _window: tauri::Window,
     key: String,
 ) -> Result<(), String> {
     println!("key {}:", key);
@@ -94,7 +94,7 @@ pub async fn change_shortcut<R: Runtime>(
 }
 
 /// Helper function to register a shortcut, used for shortcut updates.
-fn _register_shortcut<R: Runtime>(app: &AppHandle<R>, shortcut: Shortcut) {
+fn _register_shortcut(app: &AppHandle, shortcut: Shortcut) {
     app.global_shortcut()
         .on_shortcut(shortcut, move |app, scut, event| {
             if scut == &shortcut {
@@ -151,7 +151,7 @@ fn _register_shortcut_upon_start(app: &App, shortcut: Shortcut) {
 }
 
 /// Helper function to get the stored global shortcut, as a string.
-pub fn _get_shortcut<R: Runtime>(app: &AppHandle<R>) -> String {
+pub fn _get_shortcut(app: &AppHandle) -> String {
     let store = app
         .get_store(COCO_TAURI_STORE)
         .expect("store should be loaded or created");

--- a/src-tauri/src/util/mod.rs
+++ b/src-tauri/src/util/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod platform;
 pub(crate) mod updater;
 
 use std::{path::Path, process::Command};
-use tauri::{AppHandle, Runtime};
+use tauri::AppHandle;
 use tauri_plugin_shell::ShellExt;
 
 /// We use this env variable to determine the DE on Linux.
@@ -88,7 +88,7 @@ fn get_linux_desktop_environment() -> Option<LinuxDesktopEnvironment> {
 //
 // tauri_plugin_shell::open() is deprecated, but we still use it.
 #[allow(deprecated)]
-pub async fn open<R: Runtime>(app_handle: AppHandle<R>, path: String) -> Result<(), String> {
+pub async fn open(app_handle: AppHandle, path: String) -> Result<(), String> {
     if cfg!(target_os = "linux") {
         let borrowed_path = Path::new(&path);
         if let Some(file_extension) = borrowed_path.extension() {


### PR DESCRIPTION
This commit removes the generic argument R from all the AppHandle imports, which is feasible as it has a default type. This change is made not only for simplicity, but also **consistency**. Trait SearchSource uses this type:

```rust
pub trait SearchSource {
    async fn search(
        &self,
        tauri_app_handle: AppHandle,
        query: SearchQuery,
    ) -> Result<QueryResponse, SearchError>;
}
```

In order to make trait SearchSource object-safe, the AppHandle used in it cannot contain generic arguments. So some parts of Coco already omit this generic argument. This commit cleans up the remaining instances and unifies the usage project-wide.


## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation