### PR TITLE
feat: impl extension settings 'hide_before_open'

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -18,6 +18,7 @@ Information about release notes of Coco App is provided here.
 - feat: support sending files in chat messages #764
 - feat: sub extension can set 'platforms' now #847
 - feat: add extension uninstall option in settings #855
+- feat: impl extension settings 'hide_before_open' #862
 
 ### 🐛 Bug fix
 

--- a/src-tauri/src/common/document.rs
+++ b/src-tauri/src/common/document.rs
@@ -1,3 +1,4 @@
+use crate::extension::ExtensionSettings;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tauri::AppHandle;
@@ -30,17 +31,40 @@ pub struct EditorInfo {
     pub timestamp: Option<String>,
 }
 
-/// Defines the action that would be performed when a document gets opened.
+/// Defines the action that would be performed when a [document](Document) gets opened.
+///
+/// "Document" is a uniform type that the backend uses to send the search results
+/// back to the frontend.  Since Coco can search many sources, "Document" can
+/// represent different things, application, web page, local file, extensions, and
+/// so on.  Each has its own specific open action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum OnOpened {
     /// Launch the application
     Application { app_path: String },
     /// Open the URL.
     Document { url: String },
+    /// The document is an extension.
+    Extension(ExtensionOnOpened),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ExtensionOnOpened {
+    /// Different types of extensions have different open behaviors.
+    pub(crate) ty: ExtensionOnOpenedType,
+    /// Extensions settings.  Some could affect open action.
+    ///
+    /// Optional because not all extensions have their settings.
+    pub(crate) settings: Option<ExtensionSettings>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) enum ExtensionOnOpenedType {
     /// Spawn a child process to run the `CommandAction`.
     Command {
         action: crate::extension::CommandAction,
     },
+    /// Open the `link`.
+    //
     // NOTE that this variant has the same definition as `struct Quicklink`, but we
     // cannot use it directly, its `link` field should be deserialized/serialized
     // from/to a string, but we need a JSON object here.
@@ -57,20 +81,24 @@ impl OnOpened {
         match self {
             Self::Application { app_path } => app_path.clone(),
             Self::Document { url } => url.clone(),
-            Self::Command { action } => {
-                const WHITESPACE: &str = " ";
-                let mut ret = action.exec.clone();
-                ret.push_str(WHITESPACE);
-                if let Some(ref args) = action.args {
-                    ret.push_str(args.join(WHITESPACE).as_str());
-                }
+            Self::Extension(ext_on_opened) => {
+                match &ext_on_opened.ty {
+                    ExtensionOnOpenedType::Command { action } => {
+                        const WHITESPACE: &str = " ";
+                        let mut ret = action.exec.clone();
+                        ret.push_str(WHITESPACE);
+                        if let Some(ref args) = action.args {
+                            ret.push_str(args.join(WHITESPACE).as_str());
+                        }
 
-                ret
+                        ret
+                    }
+                    // Currently, our URL is static and does not support dynamic parameters.
+                    // The URL of a quicklink is nearly useless without such dynamic user
+                    // inputs, so until we have dynamic URL support, we just use "N/A".
+                    ExtensionOnOpenedType::Quicklink { .. } => String::from("N/A"),
+                }
             }
-            // Currently, our URL is static and does not support dynamic parameters.
-            // The URL of a quicklink is nearly useless without such dynamic user
-            // inputs, so until we have dynamic URL support, we just use "N/A".
-            Self::Quicklink { .. } => String::from("N/A"),
         }
     }
 }
@@ -95,65 +123,78 @@ pub(crate) async fn open(
 
             homemade_tauri_shell_open(tauri_app_handle.clone(), url).await?
         }
-        OnOpened::Command { action } => {
-            log::debug!("open (execute) command [{:?}]", action);
-
-            let mut cmd = Command::new(action.exec);
-            if let Some(args) = action.args {
-                cmd.args(args);
-            }
-            let output = cmd.output().map_err(|e| e.to_string())?;
-            // Sometimes, we wanna see the result in logs even though it doesn't fail.
-            log::debug!(
-                "executing open(Command) result, exit code: [{}], stdout: [{}], stderr: [{}]",
-                output.status,
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
-            );
-            if !output.status.success() {
-                log::warn!(
-                    "executing open(Command) failed, exit code: [{}], stdout: [{}], stderr: [{}]",
-                    output.status,
-                    String::from_utf8_lossy(&output.stdout),
-                    String::from_utf8_lossy(&output.stderr)
-                );
-
-                return Err(format!(
-                    "Command failed, stderr [{}]",
-                    String::from_utf8_lossy(&output.stderr)
-                ));
-            }
-        }
-        OnOpened::Quicklink {
-            link,
-            open_with: opt_open_with,
-        } => {
-            let url = link.concatenate_url(&extra_args);
-
-            log::debug!("open quicklink [{}] with [{:?}]", url, opt_open_with);
-
-            cfg_if::cfg_if! {
-                // The `open_with` functionality is only supported on macOS, provided
-                // by the `open -a` command.
-                if #[cfg(target_os = "macos")] {
-                    let mut cmd = Command::new("open");
-                    if let Some(ref open_with) = opt_open_with {
-                        cmd.arg("-a");
-                        cmd.arg(open_with.as_str());
+        OnOpened::Extension(ext_on_opened) => {
+            // Apply the settings that would affect open behavior
+            if let Some(settings) = ext_on_opened.settings {
+                if let Some(should_hide) = settings.hide_before_open {
+                    if should_hide {
+                        crate::hide_coco(tauri_app_handle.clone()).await;
                     }
-                    cmd.arg(&url);
+                }
+            }
 
-                    let output = cmd.output().map_err(|e| format!("failed to spawn [open] due to error [{}]", e))?;
+            match ext_on_opened.ty {
+                ExtensionOnOpenedType::Command { action } => {
+                    log::debug!("open (execute) command [{:?}]", action);
 
-                    if !output.status.success() {
-                      return Err(format!(
-                        "failed to open with app {:?}: {}",
-                        opt_open_with,
+                    let mut cmd = Command::new(action.exec);
+                    if let Some(args) = action.args {
+                        cmd.args(args);
+                    }
+                    let output = cmd.output().map_err(|e| e.to_string())?;
+                    // Sometimes, we wanna see the result in logs even though it doesn't fail.
+                    log::debug!(
+                        "executing open(Command) result, exit code: [{}], stdout: [{}], stderr: [{}]",
+                        output.status,
+                        String::from_utf8_lossy(&output.stdout),
                         String::from_utf8_lossy(&output.stderr)
-                      ));
+                    );
+                    if !output.status.success() {
+                        log::warn!(
+                            "executing open(Command) failed, exit code: [{}], stdout: [{}], stderr: [{}]",
+                            output.status,
+                            String::from_utf8_lossy(&output.stdout),
+                            String::from_utf8_lossy(&output.stderr)
+                        );
+
+                        return Err(format!(
+                            "Command failed, stderr [{}]",
+                            String::from_utf8_lossy(&output.stderr)
+                        ));
                     }
-                } else {
-                    homemade_tauri_shell_open(tauri_app_handle.clone(), url).await?
+                }
+                ExtensionOnOpenedType::Quicklink {
+                    link,
+                    open_with: opt_open_with,
+                } => {
+                    let url = link.concatenate_url(&extra_args);
+
+                    log::debug!("open quicklink [{}] with [{:?}]", url, opt_open_with);
+
+                    cfg_if::cfg_if! {
+                        // The `open_with` functionality is only supported on macOS, provided
+                        // by the `open -a` command.
+                        if #[cfg(target_os = "macos")] {
+                            let mut cmd = Command::new("open");
+                            if let Some(ref open_with) = opt_open_with {
+                                cmd.arg("-a");
+                                cmd.arg(open_with.as_str());
+                            }
+                            cmd.arg(&url);
+
+                            let output = cmd.output().map_err(|e| format!("failed to spawn [open] due to error [{}]", e))?;
+
+                            if !output.status.success() {
+                              return Err(format!(
+                                "failed to open with app {:?}: {}",
+                                opt_open_with,
+                                String::from_utf8_lossy(&output.stderr)
+                              ));
+                            }
+                        } else {
+                            homemade_tauri_shell_open(tauri_app_handle.clone(), url).await?
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This commit implementes a new extension setting entry "hide_before_open":

> Extension plugin.json

```json
{
  "name": "Screenshot",
  "settings": {
    "hide_before_open": true
  }
}
```

that, if set to true, Coco will hide the main window before opening the extension.

Only entensions that can be opened can set their "settings" field, a check rule is added to guarantee this.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [x] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation