### PR TITLE
refactor: index iOS apps and macOS apps that store icon in Assets.car

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -36,6 +36,7 @@ Information about release notes of Coco App is provided here.
 - refactor: pinning window won't set CanJoinAllSpaces on macOS #854
 - build: web component build error #858
 - refactor: coordinate third-party extension operations using lock #867
+- refactor: index iOS apps and macOS apps that store icon in Assets.car #872
 
 ## 0.7.1 (2025-07-27)
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 [[package]]
 name = "applications"
 version = "0.3.1"
-source = "git+https://github.com/infinilabs/applications-rs?rev=31b0c030a0f3bc82275fe12debe526153978671d#31b0c030a0f3bc82275fe12debe526153978671d"
+source = "git+https://github.com/infinilabs/applications-rs?rev=814b16ea84fc0c5aa432fc094dfd9aceb83f7e46#814b16ea84fc0c5aa432fc094dfd9aceb83f7e46"
 dependencies = [
  "anyhow",
  "core-foundation 0.9.4",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ tauri-plugin-drag = "2"
 tauri-plugin-macos-permissions = "2"
 tauri-plugin-fs-pro = "2"
 tauri-plugin-screenshots = "2"
-applications = { git = "https://github.com/infinilabs/applications-rs", rev = "31b0c030a0f3bc82275fe12debe526153978671d" }
+applications = { git = "https://github.com/infinilabs/applications-rs", rev = "814b16ea84fc0c5aa432fc094dfd9aceb83f7e46" }
 tokio-native-tls = "0.3"  # For wss connections
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.20", features = ["native-tls"] }

--- a/src-tauri/src/extension/built_in/application/with_feature.rs
+++ b/src-tauri/src/extension/built_in/application/with_feature.rs
@@ -58,37 +58,18 @@ const INDEX_DIR: &str = "local_application_index";
 pub(crate) const QUERYSOURCE_ID_DATASOURCE_ID_DATASOURCE_NAME: &str = "Applications";
 
 pub fn get_default_search_paths() -> Vec<String> {
-    #[cfg(target_os = "macos")]
-    {
-        let home_dir =
-            PathBuf::from(std::env::var_os("HOME").expect("environment variable $HOME not found"));
-        return vec![
-            "/Applications".into(),
-            "/System/Applications".into(),
-            "/System/Library/CoreServices".into(),
-            home_dir
-                .join("Applications")
-                .into_os_string()
-                .into_string()
-                .expect("this path should be UTF-8 encoded"),
-        ];
+    let paths = applications::get_default_search_paths();
+    let mut ret = Vec::with_capacity(paths.len());
+    for search_path in paths {
+        let path_string = search_path
+            .into_os_string()
+            .into_string()
+            .expect("path should be UTF-8 encoded");
+
+        ret.push(path_string);
     }
 
-    #[cfg(not(target_os = "macos"))]
-    {
-        let paths = applications::get_default_search_paths();
-        let mut ret = Vec::with_capacity(paths.len());
-        for search_path in paths {
-            let path_string = search_path
-                .into_os_string()
-                .into_string()
-                .expect("path should be UTF-8 encoded");
-
-            ret.push(path_string);
-        }
-
-        ret
-    }
+    ret
 }
 
 /// Helper function to return `app`'s path.


### PR DESCRIPTION
Bumps the 'applications' crate to include this commit[1].  With this, Coco now indexes iOS apps and macOS apps that store icons in Assets.car.

[1]: https://github.com/infinilabs/applications-rs/commit/814b16ea84fc0c5aa432fc094dfd9aceb83f7e46

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation