### PR TITLE
feat: index both en/zh_CN app names and show app name in Coco app language

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -19,6 +19,7 @@ Information about release notes of Coco App is provided here.
 - feat: sub extension can set 'platforms' now #847
 - feat: add extension uninstall option in settings #855
 - feat: impl extension settings 'hide_before_open' #862
+- feat: index both en/zh_CN app names and show app name in chosen language #875
 
 ### 🐛 Bug fix
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -879,6 +879,7 @@ dependencies = [
  "serde_plain",
  "strsim 0.10.0",
  "strum",
+ "sys-locale",
  "sysinfo",
  "tauri",
  "tauri-build",
@@ -3201,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libdbus-sys"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 [[package]]
 name = "applications"
 version = "0.3.1"
-source = "git+https://github.com/infinilabs/applications-rs?rev=814b16ea84fc0c5aa432fc094dfd9aceb83f7e46#814b16ea84fc0c5aa432fc094dfd9aceb83f7e46"
+source = "git+https://github.com/infinilabs/applications-rs?rev=2f1f88d1880404c5f8d70ad950b859bd49922bee#2f1f88d1880404c5f8d70ad950b859bd49922bee"
 dependencies = [
  "anyhow",
  "core-foundation 0.9.4",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -107,6 +107,7 @@ cfg-if = "1.0.1"
 sysinfo = "0.35.2"
 indexmap = { version = "2.10.0", features = ["serde"] }
 strum = { version = "0.27.2", features = ["derive"] }
+sys-locale = "0.3.2"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2" }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ tauri-plugin-drag = "2"
 tauri-plugin-macos-permissions = "2"
 tauri-plugin-fs-pro = "2"
 tauri-plugin-screenshots = "2"
-applications = { git = "https://github.com/infinilabs/applications-rs", rev = "814b16ea84fc0c5aa432fc094dfd9aceb83f7e46" }
+applications = { git = "https://github.com/infinilabs/applications-rs", rev = "2f1f88d1880404c5f8d70ad950b859bd49922bee" }
 tokio-native-tls = "0.3"  # For wss connections
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.20", features = ["native-tls"] }

--- a/src-tauri/src/util/mod.rs
+++ b/src-tauri/src/util/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod app_lang;
 pub(crate) mod file;
 pub(crate) mod platform;
+pub(crate) mod system_lang;
 pub(crate) mod updater;
 
 use std::{path::Path, process::Command};

--- a/src-tauri/src/util/system_lang.rs
+++ b/src-tauri/src/util/system_lang.rs
@@ -1,0 +1,13 @@
+use sys_locale::get_locale;
+
+/// Helper function to get the system language.
+///
+/// We cannot return `enum Lang` here because Coco has limited language support
+/// but the OS supports many more languages.
+pub(crate) fn get_system_lang() -> String {
+    // fall back to English (general) when we cannot get the locale
+    //
+    // We replace '-' with '_' in applications-rs, to make the locales match,
+    // we need to do this here as well.
+    get_locale().unwrap_or("en".into()).replace('-', "_")
+}


### PR DESCRIPTION
After this commit, we index both English and Chinese application names so that searches in either language will work.  And the names of the applications in search results and application list will be in the app language.

Pizza index structure has been updated, but backward compatibility is preserved by keeping the support code for the old index field.

The changes in this commit are not macOS-specific, it applies to all supported platforms.  Though this feature won't work on Linux and Windows until we implement the localized app name support in the underlying applications-rs crate.

<img width="1796" height="788" alt="Screenshot 2025-08-18 at 6 04 54 PM" src="https://github.com/user-attachments/assets/37d71c08-53c3-45aa-828a-0812b4b71ce5" />



## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation