### PR TITLE
refactor: accept both '-' and '_' as locale str separator

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -38,6 +38,7 @@ Information about release notes of Coco App is provided here.
 - build: web component build error #858
 - refactor: coordinate third-party extension operations using lock #867
 - refactor: index iOS apps and macOS apps that store icon in Assets.car #872
+- refactor: accept both '-' and '_' as locale str separator #876
 
 ## 0.7.1 (2025-07-27)
 

--- a/src-tauri/src/extension/built_in/application/with_feature.rs
+++ b/src-tauri/src/extension/built_in/application/with_feature.rs
@@ -104,12 +104,19 @@ fn get_app_path(app: &App) -> String {
 
 /// Helper function to return `app`'s Chinese name.
 async fn get_app_name_zh(app: &App) -> String {
-    // First try zh_CN
+    // zh_CN or zh-CN
     if let Some(name) = app.localized_app_names.get("zh_CN") {
         return name.clone();
     }
-    // Then try zh_Hans
+    if let Some(name) = app.localized_app_names.get("zh-CN") {
+        return name.clone();
+    }
+
+    // zh_Hans or zh-Hans
     if let Some(name) = app.localized_app_names.get("zh_Hans") {
+        return name.clone();
+    }
+    if let Some(name) = app.localized_app_names.get("zh-Hans") {
         return name.clone();
     }
 
@@ -119,11 +126,15 @@ async fn get_app_name_zh(app: &App) -> String {
 
 /// Helper function to return `app`'s English name.
 async fn get_app_name_en(app: &App) -> String {
-    // First try en_US
+    // en_US or en-US
     if let Some(name) = app.localized_app_names.get("en_US") {
         return name.clone();
     }
-    // Then try en
+    if let Some(name) = app.localized_app_names.get("en-US") {
+        return name.clone();
+    }
+
+    // English (General)
     if let Some(name) = app.localized_app_names.get("en") {
         return name.clone();
     }
@@ -136,7 +147,6 @@ async fn get_app_name_en(app: &App) -> String {
 async fn get_app_name_in_system_lang(app: &App) -> String {
     let system_lang = crate::util::system_lang::get_system_lang();
 
-    // First try en_US
     if let Some(name) = app.localized_app_names.get(&system_lang) {
         name.clone()
     } else {

--- a/src-tauri/src/util/app_lang.rs
+++ b/src-tauri/src/util/app_lang.rs
@@ -22,6 +22,10 @@ impl std::fmt::Display for Lang {
     }
 }
 
+/// Frontend code uses "en" and "zh" to represent the Application language.
+///
+/// This impl is not meant to be used as a parser for locale strings such as
+/// "en_US" or "zh_CN".
 impl std::str::FromStr for Lang {
     type Err = String;
 


### PR DESCRIPTION
I wasn't aware that both '-' (specified by the standard) and '_' (not in the standard, but is commonly used) can be used as the tag delimiter in locale strings[1] when I originally wrote this commit[2].

Both "zh-CN" and "zh_CN" are valid locale strings!

Since '_' is more commonly used, I thought it was the only correct form and thus our code only accepts it.

This commit refactors the implementation to accept both.

[1]: https://stackoverflow.com/a/36752015/14092446
[2]: https://github.com/infinilabs/coco-app/commit/f5b33af7f1f4a45ad180d56e73a63a0d3bcceeb5

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation