### PR TITLE
fix: set up hotkey on main thread or Windows will complain

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -25,6 +25,8 @@ Information about release notes of Coco App is provided here.
 
 - fix: fix issue with update check failure #833
 - fix: web component login state #857
+- fix: set up hotkey on main thread or Windows will complain #879
+
 
 ### ✈️ Improvements
 

--- a/src-tauri/src/setup/mod.rs
+++ b/src-tauri/src/setup/mod.rs
@@ -77,7 +77,16 @@ pub(crate) async fn backend_setup(tauri_app_handle: AppHandle, app_lang: String)
     // This has to be called before initializing extensions as doing that
     // requires access to the shortcut store, which will be set by this
     // function.
-    crate::shortcut::enable_shortcut(&tauri_app_handle);
+    //
+    //
+    // Windows requires that hotkey setup has to be done on the main thread, or
+    // we will get error "ERROR_WINDOW_OF_OTHER_THREAD 1408 (0x580)"
+    let tauri_app_handle_clone = tauri_app_handle.clone();
+    tauri_app_handle
+        .run_on_main_thread(move || {
+            crate::shortcut::enable_shortcut(&tauri_app_handle_clone);
+        })
+        .expect("failed to run this closure on the main thread");
 
     crate::init(&tauri_app_handle).await;
 


### PR DESCRIPTION
Coco panicked on Windows when I was testing the applications-rs crate on Windows, the error message seemingly indicates that we should run hotkey setup on the main thread, and doing that indeed fixes the issue, so let's do it.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation