### PR TITLE
chore: bump applications-rs to latest commit

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 [[package]]
 name = "applications"
 version = "0.3.1"
-source = "git+https://github.com/infinilabs/applications-rs?rev=2f1f88d1880404c5f8d70ad950b859bd49922bee#2f1f88d1880404c5f8d70ad950b859bd49922bee"
+source = "git+https://github.com/infinilabs/applications-rs?rev=e80a301e07f9a9a1a82ec038141232d22eba78be#e80a301e07f9a9a1a82ec038141232d22eba78be"
 dependencies = [
  "anyhow",
  "core-foundation 0.9.4",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ tauri-plugin-drag = "2"
 tauri-plugin-macos-permissions = "2"
 tauri-plugin-fs-pro = "2"
 tauri-plugin-screenshots = "2"
-applications = { git = "https://github.com/infinilabs/applications-rs", rev = "2f1f88d1880404c5f8d70ad950b859bd49922bee" }
+applications = { git = "https://github.com/infinilabs/applications-rs", rev = "e80a301e07f9a9a1a82ec038141232d22eba78be" }
 tokio-native-tls = "0.3"  # For wss connections
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.20", features = ["native-tls"] }


### PR DESCRIPTION
Bump it to include the support of localized app names for Linux.

<img width="553" height="462" alt="Screenshot 2025-08-20 at 5 22 31 PM" src="https://github.com/user-attachments/assets/75790de9-d9b0-4a7b-af49-d93c21a01193" />



## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation