### PR TITLE
refactor: relax the file search conditions on macOS

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -43,6 +43,7 @@ Information about release notes of Coco App is provided here.
 - refactor: coordinate third-party extension operations using lock #867
 - refactor: index iOS apps and macOS apps that store icon in Assets.car #872
 - refactor: accept both '-' and '\_' as locale str separator #876
+- refactor: relax the file search conditions on macOS #883
 
 ## 0.7.1 (2025-07-27)
 

--- a/src-tauri/src/extension/built_in/file_search/implementation/macos.rs
+++ b/src-tauri/src/extension/built_in/file_search/implementation/macos.rs
@@ -100,7 +100,7 @@ fn build_mdfind_query(query_string: &str, config: &FileSearchConfig) -> Vec<Stri
         }
         SearchBy::NameAndContents => {
             // Do not specify any File System Metadata Attribute Keys to search
-            // all of them.
+            // all of them, it is case-insensitive by default.
             //
             // Previously, we use:
             //

--- a/src-tauri/src/extension/built_in/file_search/implementation/macos.rs
+++ b/src-tauri/src/extension/built_in/file_search/implementation/macos.rs
@@ -91,7 +91,7 @@ fn build_mdfind_query(query_string: &str, config: &FileSearchConfig) -> Vec<Stri
             // The tailing char 'c' makes the search case-insensitive.
             //
             // According to [1], we should use this syntax "kMDItemFSName ==[c] '*{}*'",
-            // but it does not work on my machine (macOS 26 beta 7), and you 
+            // but it does not work on my machine (macOS 26 beta 7), and you
             // can find similar complaints as well [2].
             //
             // [1]: https://developer.apple.com/library/archive/documentation/Carbon/Conceptual/SpotlightQuery/Concepts/QueryFormat.html
@@ -107,7 +107,7 @@ fn build_mdfind_query(query_string: &str, config: &FileSearchConfig) -> Vec<Stri
             //    "kMDItemFSName == '*{}*' || kMDItemTextContent == '{}'"
             //
             // But the kMDItemTextContent attribute does not work as expected.
-            // For example, if a PDF document contains both "Waterloo" and 
+            // For example, if a PDF document contains both "Waterloo" and
             // "waterloo", it is only matched by "Waterloo".
             args.push(query_string.to_string());
         }

--- a/src-tauri/src/extension/built_in/file_search/implementation/macos.rs
+++ b/src-tauri/src/extension/built_in/file_search/implementation/macos.rs
@@ -88,13 +88,28 @@ fn build_mdfind_query(query_string: &str, config: &FileSearchConfig) -> Vec<Stri
 
     match config.search_by {
         SearchBy::Name => {
-            args.push(format!("kMDItemFSName == '*{}*'", query_string));
+            // The tailing char 'c' makes the search case-insensitive.
+            //
+            // According to [1], we should use this syntax "kMDItemFSName ==[c] '*{}*'",
+            // but it does not work on my machine (macOS 26 beta 7), and you 
+            // can find similar complaints as well [2].
+            //
+            // [1]: https://developer.apple.com/library/archive/documentation/Carbon/Conceptual/SpotlightQuery/Concepts/QueryFormat.html
+            // [2]: https://apple.stackexchange.com/q/263671/394687
+            args.push(format!("kMDItemFSName == '*{}*'c", query_string));
         }
         SearchBy::NameAndContents => {
-            args.push(format!(
-                "kMDItemFSName == '*{}*' || kMDItemTextContent == '{}'",
-                query_string, query_string
-            ));
+            // Do not specify any File System Metadata Attribute Keys to search
+            // all of them.
+            //
+            // Previously, we use:
+            //
+            //    "kMDItemFSName == '*{}*' || kMDItemTextContent == '{}'"
+            //
+            // But the kMDItemTextContent attribute does not work as expected.
+            // For example, if a PDF document contains both "Waterloo" and 
+            // "waterloo", it is only matched by "Waterloo".
+            args.push(query_string.to_string());
         }
     }
 


### PR DESCRIPTION
This commit makes the file search conditions more permissive on macOS:

* Searching by filename

  Now this is case-insensitive

* Searching by filename and content

  We previously only searched for 2 attributes:

  1. kMDItemFSName
  2. kMDItemTextContent

  as the semantics should be exactly right (Search fileanme and content).  But
  kMDItemTextContent does not work as expected.  For example, if a PDF document
  contains both "Waterloo" and "waterloo", it is only matched by "Waterloo".

  To workaround this (I consider this a bug of Spotlight), now we search all
  the attributes.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation