### PR TITLE
fix: use kill_on_drop() to avoid zombie proc in error case

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -32,6 +32,7 @@ Information about release notes of Coco App is provided here.
 - fix: shortcut key not opening extension store #877
 - fix: set up hotkey on main thread or Windows will complain #879
 - fix: resolve deeplink login issue #881
+- fix: use kill_on_drop() to avoid zombie proc in error case #887
 
 ### ✈️ Improvements
 


### PR DESCRIPTION
In the previous macOS file search implementation, we spawned an mdfind child process and killed it when we got the results we needed to avoid zombie processes.  However, this kill step would be skipped if an error happened during query results processing as we propagate errors.

This commit replaces the manual kill operation with the `ChildProcHandle.kill_on_drop()` API to let RAII do the job to fix the issue.


## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation