### PR TITLE
chore: clean up unused warning

### DIFF
--- a/src-tauri/src/util/system_lang.rs
+++ b/src-tauri/src/util/system_lang.rs
@@ -1,10 +1,11 @@
-use sys_locale::get_locale;
-
 /// Helper function to get the system language.
 ///
 /// We cannot return `enum Lang` here because Coco has limited language support
 /// but the OS supports many more languages.
+#[cfg(feature = "use_pizza_engine")]
 pub(crate) fn get_system_lang() -> String {
+    use sys_locale::get_locale;
+
     // fall back to English (general) when we cannot get the locale
     //
     // We replace '-' with '_' in applications-rs, to make the locales match,


### PR DESCRIPTION
The function `get_system_lang()` will only be used when the feature "use_pizza_engine" is enabled, feature-gate it to clear the compiler warning.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation