### PR TITLE
fix: settings window rendering/loading issue

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -34,6 +34,7 @@ Information about release notes of Coco App is provided here.
 - fix: set up hotkey on main thread or Windows will complain #879
 - fix: resolve deeplink login issue #881
 - fix: use kill_on_drop() to avoid zombie proc in error case #887
+- fix: settings window rendering/loading issue 889
 
 ### ✈️ Improvements
 

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -1,45 +1,21 @@
-import { useMount, useSessionStorageState } from "ahooks";
-import { useEffect } from "react";
+import { useMount } from "ahooks";
+import { useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 
 import LayoutOutlet from "./outlet";
 import { useAppStore } from "@/stores/appStore";
-import platformAdapter from "@/utils/platformAdapter";
-import { CHAT_WINDOW_LABEL, MAIN_WINDOW_LABEL } from "@/constants";
 
 const Layout = () => {
   const { language } = useAppStore();
-  const [ready, setReady] = useSessionStorageState("rust_ready", {
-    defaultValue: false,
-  });
+  const [ready, setReady] = useState(false);
 
   useMount(async () => {
-    const label = await platformAdapter.getCurrentWindowLabel();
-
-    if (label === CHAT_WINDOW_LABEL) {
-      setReady(true);
-    }
-
-    if (ready || label !== MAIN_WINDOW_LABEL) return;
-
     await invoke("backend_setup", {
       appLang: language,
     });
 
     setReady(true);
-
-    platformAdapter.emitEvent("rust_ready");
   });
-
-  useEffect(() => {
-    const unlisten = platformAdapter.listenEvent("rust_ready", () => {
-      setReady(true);
-    });
-
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, []);
 
   return ready && <LayoutOutlet />;
 };

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -47,7 +47,6 @@ export interface EventPayloads {
   "check-update": any;
   oauth_success: any;
   extension_install_success: any;
-  rust_ready: boolean;
 }
 
 // Window operation interface


### PR DESCRIPTION
This commit fixes(I guess?) the issue that the Settings window may not be
rendered or loaded, you will see that the whole window is gray in that case.

Background, aka, why this issue exists
=============================================================

In commit [1], we wrapped all the backend setup routines in a tauri command, so
that frontend code can call it before invoking any other backend interfaces to
guarantee that these interfaces won't be called until the data/state they rely
on is ready.

The implementation in [1] had an issue that it didn't work with window reloading.
To fix this issue, we made another commit [2].  Commit [2] fixed the refresh
issue, but it also caused the settings window issue that this commit tries to fix.

The backend setup tauri command needs a state to track whether the setup has
completed.  In the previous implementation, this was done in the frontend.  In
this commit, it is moved to the backend.

Why didn't you guys move that state to backend in previous commits, e.g., commit [2]?
=============================================================

We tried, but failed.  In the previous tries, the backend would send an event
to the frontend, but the frontend couldn't receive it, for reasons we still
don’t understand.  And this weird issue still exists, we just happen to find
a way to work around it.

[1]: https://github.com/infinilabs/coco-app/commit/f93c527561aaa4322918fca913df1e38c8265e0e
[2]: https://github.com/infinilabs/coco-app/commit/993da9a8ad0cd51a5361ec9c84ed0a65fad5f94a


## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation