### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ At Coco AI, we aim to streamline workplace collaboration by centralizing access 
 
 ### Prerequisites
 
-- Node.js >= 18.12
-- Rust (latest stable)
-- pnpm (package manager)
+- [Node.js >= 18.12](https://nodejs.org/en/download/)
+- [Rust (latest stable)](https://www.rust-lang.org/tools/install)
+- [pnpm (package manager)](https://pnpm.io/installation)
 
 ### Development Setup
 


### PR DESCRIPTION
docs(README): add official download links for prerequisites

## What does this PR do
Add official download/installation links to the README *Prerequisites* list:
- Node.js → https://nodejs.org/en/download/
- Rust → https://www.rust-lang.org/tools/install
- pnpm → https://pnpm.io/installation

No code change, docs-only.

## Rationale for this change
Help new contributors/users install the required tools faster and from official sources, reducing onboarding friction and avoiding third-party download confusion.

## Standards checklist
- [x] The PR title is descriptive
- [x] The commit messages are semantic
- [ ] Necessary tests are added *(N/A: docs only)*
- [ ] Updated the release notes *(N/A)*
- [ ] Necessary documents have been added if this is a new feature *(N/A)*
- [ ] Performance tests checked, no obvious performance degradation *(N/A: docs only)*