### PR TITLE
fix: bump applications-rs to fix empty app name issue

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -38,6 +38,7 @@ Information about release notes of Coco App is provided here.
 - fix: use kill_on_drop() to avoid zombie proc in error case #887
 - fix: settings window rendering/loading issue 889
 - fix: ensure search paths are indexed #896
+- fix: bump applications-rs to fix empty app name issue #898
 
 ### ✈️ Improvements
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -126,7 +126,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 [[package]]
 name = "applications"
 version = "0.3.1"
-source = "git+https://github.com/infinilabs/applications-rs?rev=e80a301e07f9a9a1a82ec038141232d22eba78be#e80a301e07f9a9a1a82ec038141232d22eba78be"
+source = "git+https://github.com/infinilabs/applications-rs?rev=b5fac4034a40d42e72f727f1aa1cc1f19fe86653#b5fac4034a40d42e72f727f1aa1cc1f19fe86653"
 dependencies = [
  "anyhow",
  "core-foundation 0.9.4",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,7 +62,7 @@ tauri-plugin-drag = "2"
 tauri-plugin-macos-permissions = "2"
 tauri-plugin-fs-pro = "2"
 tauri-plugin-screenshots = "2"
-applications = { git = "https://github.com/infinilabs/applications-rs", rev = "e80a301e07f9a9a1a82ec038141232d22eba78be" }
+applications = { git = "https://github.com/infinilabs/applications-rs", rev = "b5fac4034a40d42e72f727f1aa1cc1f19fe86653" }
 tokio-native-tls = "0.3"  # For wss connections
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.20", features = ["native-tls"] }


### PR DESCRIPTION
The previous versions of applications-rs would use CFBundleDisplayName or CFBundleName as the app name even though they were empty. Bump to the latest commit to fix the issue.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation