### PR TITLE
chore: convertFileSrc() "link[href]" and "img[src]"

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -56,6 +56,7 @@ Information about release notes of Coco App is provided here.
 - refactor: relax the file search conditions on macOS #883
 - refactor: ensure Coco won't take focus #891
 - chore: skip login check for web widget #895
+- chore: convertFileSrc() "link[href]" and "img[src]" #901
 
 ## 0.7.1 (2025-07-27)
 


### PR DESCRIPTION
These 2 tags could contain local file paths, we need to `convertFileSrc()` them as well.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [x] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation