### PR TITLE
chore: release 0.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils libtracker-sparql-3.0-dev
 
+
+      # On Windows, we need to generate bindings for 'searchapi.h' using bindgen.
+      # And bindgen relies on 'libclang'
+      # https://rust-lang.github.io/rust-bindgen/requirements.html#windows
+      - name: Install dependencies (Windows only)
+        if: startsWith(matrix.platform, 'windows-latest')
+        shell: bash
+        run: winget install LLVM.LLVM --silent --accept-package-agreements --accept-source-agreements
+
+
       - name: Add Rust build target
         working-directory: src-tauri
         shell: bash

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -8,6 +8,13 @@ title: "Release Notes"
 Information about release notes of Coco App is provided here.
 
 ## Latest (In development)
+### ❌ Breaking changes
+### 🚀 Features
+### 🐛 Bug fix
+### ✈️ Improvements
+
+
+## 0.8.0 (2025-09-28)
 
 ### ❌ Breaking changes
 


### PR DESCRIPTION
1. Update the release notes
2. Install the missing libclang dependency in pipeline ".github/workflows/release.yml"

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation