### PR TITLE
fix: default hide_before_open to true only for Command extensions

### DIFF
--- a/src-tauri/src/common/document.rs
+++ b/src-tauri/src/common/document.rs
@@ -180,10 +180,8 @@ pub(crate) async fn open(
                 // Apply the settings that would affect open behavior
                 // Default to hiding the Coco window before opening for Command extensions,
                 // keep the window visible for other extension types unless explicitly configured
-                let default_hide = matches!(
-                    ext_on_opened.ty,
-                    ExtensionOnOpenedType::Command { .. }
-                );
+                let default_hide =
+                    matches!(ext_on_opened.ty, ExtensionOnOpenedType::Command { .. });
                 let should_hide = ext_on_opened
                     .settings
                     .and_then(|s| s.hide_before_open)

--- a/src-tauri/src/common/document.rs
+++ b/src-tauri/src/common/document.rs
@@ -178,11 +178,16 @@ pub(crate) async fn open(
             }
             OnOpened::Extension(ext_on_opened) => {
                 // Apply the settings that would affect open behavior
-                // Default to hiding the Coco window before opening, unless explicitly disabled
+                // Default to hiding the Coco window before opening for Command extensions,
+                // keep the window visible for other extension types unless explicitly configured
+                let default_hide = matches!(
+                    ext_on_opened.ty,
+                    ExtensionOnOpenedType::Command { .. }
+                );
                 let should_hide = ext_on_opened
                     .settings
                     .and_then(|s| s.hide_before_open)
-                    .unwrap_or(true);
+                    .unwrap_or(default_hide);
                 if should_hide {
                     crate::hide_coco(tauri_app_handle.clone()).await;
                 }


### PR DESCRIPTION

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation